### PR TITLE
feat(explorer): Virtual line spacer between `Conflict`, `Staged` and `Unstaged` groups

### DIFF
--- a/lua/codediff/ui/lib/tree.lua
+++ b/lua/codediff/ui/lib/tree.lua
@@ -250,10 +250,15 @@ function Tree:render()
   -- Build lines and collect highlight info
   local lines = {}
   local line_highlights = {} -- [line_idx] = { {col_start, col_end, hl_group}, ... }
+  local line_spacers = {} -- [line_idx] = spacer_size
 
   for i, node in ipairs(visible_nodes) do
     node._line = i
     self._line_to_node[i] = node
+
+    if node.data and node.data.type == "group" and i > 1 then
+      line_spacers[i] = 1
+    end
 
     if self._prepare_node then
       local line_obj = self._prepare_node(node)
@@ -287,6 +292,19 @@ function Tree:render()
 
   -- Apply highlights
   vim.api.nvim_buf_clear_namespace(self._bufnr, self._ns_id, 0, -1)
+
+  -- Apply virtual line spacers
+  for line_idx, spacer_size in pairs(line_spacers) do
+    local virt_lines = {}
+    for _ = 1, spacer_size do
+      table.insert(virt_lines, { { "", "" } })
+    end
+    pcall(vim.api.nvim_buf_set_extmark, self._bufnr, self._ns_id, line_idx - 1, 0, {
+      virt_lines = virt_lines,
+      virt_lines_above = true,
+    })
+  end
+
   for line_idx, entries in pairs(line_highlights) do
     for _, entry in ipairs(entries) do
       pcall(vim.api.nvim_buf_set_extmark, self._bufnr, self._ns_id, line_idx - 1, entry[1], {

--- a/tests/ui/lib/lib_spec.lua
+++ b/tests/ui/lib/lib_spec.lua
@@ -510,4 +510,17 @@ describe("Tree", function()
     local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
     assert.same({ "Changes" }, lines)
   end)
+
+  it("applies a virtual top margin to group nodes that are not the first line", function()
+    local tree = Tree({ bufnr = bufnr, nodes = {
+      Tree.Node({ data = { type = "group" } }),
+      Tree.Node({ data = { type = "group" } })
+    }})
+
+    tree:render()
+
+    local marks = vim.api.nvim_buf_get_extmarks(bufnr, tree._ns_id, 0, -1, { details = true })
+    assert.equals(1, #marks[1][4].virt_lines)
+    assert.is_true(marks[1][4].virt_lines_above)
+  end)
 end)


### PR DESCRIPTION
<img width="1216" height="759" alt="image" src="https://github.com/user-attachments/assets/cbc1f181-a4ad-48b8-a904-ae58b37a9f9b" />

---

# Description

When the explorer displays dozens of files, it is easy to lose track of the boundaries between Staged, Unstaged, and Conflict groups, leading to accidental staging or unstaging of the wrong files. 

This PR introduces a single-line virtual spacer above group nodes to make it instantly clear where one section ends and another begins.

### Implementation Details

This is handled at render time. 
- A dynamic `line_spacers` table is generated during `Tree:render()`.
- Any `group` node that isn't the first visible line in the buffer gets a margin of `1`.
- The tree renderer simply loops over this table and applies native `virt_lines_above = true` extmarks.
- A test was added for this new render-time behavior

### Configuration / Opt-in

This PR applies the visual separator universally without exposing new configuration options, as it feels like a sensible and universally beneficial default for the UI. However, if you prefer this to be configurable or opt-in, I would be happy to update the PR to expose a setting for it!
