### PR TITLE
test(explorer): de-flake "refresh staged content when index changes"

### DIFF
--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -194,6 +194,23 @@ function M.wait_for_buffer_content(bufnr, expected, timeout_ms)
   end, 50)
 end
 
+--- Wait until the tabpage's *current* modified diff buffer contains `expected`.
+--- Unlike wait_for_buffer_content (fixed bufnr), this re-fetches the modified
+--- buffer on every poll, so it tolerates the buffer swap that view.update does
+--- when a diff switches between working-tree and staged (:0) revisions.
+function M.wait_for_modified_content(tabpage, expected, timeout_ms)
+  timeout_ms = timeout_ms or 5000
+  local lifecycle = require('codediff.ui.lifecycle')
+  return vim.wait(timeout_ms, function()
+    local _, mod_buf = lifecycle.get_buffers(tabpage)
+    if not mod_buf or not vim.api.nvim_buf_is_valid(mod_buf) then
+      return false
+    end
+    local lines = vim.api.nvim_buf_get_lines(mod_buf, 0, -1, false)
+    return table.concat(lines, '\n'):find(expected, 1, true) ~= nil
+  end, 50)
+end
+
 -- Get buffer content as a single string
 function M.get_buffer_content(bufnr)
   if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then

--- a/tests/ui/explorer/explorer_staging_spec.lua
+++ b/tests/ui/explorer/explorer_staging_spec.lua
@@ -159,7 +159,10 @@ describe("Explorer Buffer Management", function()
     view.update(tabpage, config_changes, false)
     ready = h.wait_for_session_ready(tabpage)
 
-    -- Validate: Changes should show "change B" (the new unstaged change)
+    -- Validate: Changes should show "change B" (the new unstaged change).
+    -- Poll the current modified buffer (view.update swaps it) until the async
+    -- re-render lands, so this doesn't race on slow CI runners.
+    h.wait_for_modified_content(tabpage, "change B", 5000)
     _, modified_buf = lifecycle.get_buffers(tabpage)
     content = h.get_buffer_content(modified_buf)
     assert.is_not_nil(content, "Step 3 content should not be nil")
@@ -185,6 +188,8 @@ describe("Explorer Buffer Management", function()
     ready = h.wait_for_session_ready(tabpage)
     assert.is_true(ready, "Session should be ready after step 4 update")
 
+    -- Wait for the staged view to reflect the newly staged change B.
+    h.wait_for_modified_content(tabpage, "change B", 5000)
     _, modified_buf = lifecycle.get_buffers(tabpage)
     content = h.get_buffer_content(modified_buf)
     h.assert_contains(content, "change A", "Staged should show change A after staging B")
@@ -197,6 +202,8 @@ describe("Explorer Buffer Management", function()
     view.update(tabpage, config_changes, false)
     ready = h.wait_for_session_ready(tabpage)
 
+    -- Wait for the changes view to reflect both A and B after unstaging.
+    h.wait_for_modified_content(tabpage, "change B", 5000)
     _, modified_buf = lifecycle.get_buffers(tabpage)
     content = h.get_buffer_content(modified_buf)
     h.assert_contains(content, "change A", "Changes should show change A after unstage")


### PR DESCRIPTION
## Summary

De-flakes the `explorer_staging_spec.lua` test **"should refresh staged content when index changes"**, which was intermittently failing the **Release** workflow (both runs #457 and #437 failed on this exact test, only on the slower runners — `ubuntu-latest-x64`, `macos-latest-arm64`). Because `version-and-tag`/`release` depend on `build-and-test`, one flaky test blocks the whole release.

## Root cause — a test race
The test wrote a new change to disk, called `view.update` (which re-renders asynchronously and **swaps** the modified buffer between working-tree and `:0`), then asserted the buffer content immediately after `wait_for_session_ready`:

```lua
if not session.stored_diff_result then return false end   -- only checks it's non-nil
```

`stored_diff_result` **persists from the previous view**, so the wait returns *before* the async re-render loads the new content. On loaded runners the assert reads stale content and `assert_contains(content, "change B")` fails. The content loads correctly a moment later — the test just checked too early.

## Fix (test-only)
- **`tests/helpers.lua`** — add `wait_for_modified_content(tabpage, expected, timeout)`: unlike the fixed-bufnr `wait_for_buffer_content`, it **re-fetches the current modified buffer on every poll**, so it tolerates the working↔`:0` buffer swap. It waits until the buffer actually contains the expected text.
- **`explorer_staging_spec.lua`** — poll at the three "change B" checkpoints (steps 3, 4, 5) before asserting.

## Proof (deterministic reproduction)
Pinning nvim to a single CPU (`taskset -c 0`) reliably surfaces the race:

| | Result |
|---|---|
| **Pre-fix** spec, 1 CPU | **2/10 flaked** (same failure as CI) |
| **Fixed** spec, 1 CPU | **0/15 flaked** |

So the fix is load-bearing, not just "passes on fast hardware."

## Notes
- Test-only change; no production code touched.
- Pre-existing on `main` — improves Release + build-and-test reliability for all PRs.
