### PR TITLE
fix: reopen closed diff panes from explorer

### DIFF
--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -11,6 +11,7 @@ local tree_module = require("codediff.ui.explorer.tree")
 local keymaps_module = require("codediff.ui.explorer.keymaps")
 local refresh_module = require("codediff.ui.explorer.refresh")
 local welcome = require("codediff.ui.welcome")
+local view_helpers = require("codediff.ui.view.helpers")
 
 local function should_show_welcome(explorer)
   if not explorer or not explorer.git_root or explorer.dir1 or explorer.dir2 then
@@ -105,6 +106,9 @@ end
 --- @param group string "staged" | "unstaged" | "conflicts"
 --- @return boolean
 local function already_showing(session, explorer, file_path, abs_path, group)
+  if not view_helpers.has_visible_panes(session) then
+    return false
+  end
   local same_file = (session.modified and session.modified.absolute == abs_path) or (session.original and session.original.absolute == abs_path)
   if not same_file then
     return false
@@ -311,6 +315,7 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
 
       local session = lifecycle.get_session(tabpage)
       local showing_already = session
+        and view_helpers.has_visible_panes(session)
         and session.original
         and session.modified
         and session.original.absolute == original.absolute

--- a/lua/codediff/ui/history/render.lua
+++ b/lua/codediff/ui/history/render.lua
@@ -318,7 +318,13 @@ function M.create(commits, git_root, tabpage, width, opts)
     -- Check if already displaying same file
     local target_hash = base_revision or (commit_hash .. "^")
     local session = lifecycle.get_session(tabpage)
-    if not opts.force and session and session.original_revision == target_hash and session.modified_revision == commit_hash then
+    if
+      not opts.force
+      and session
+      and require("codediff.ui.view.helpers").has_visible_panes(session)
+      and session.original_revision == target_hash
+      and session.modified_revision == commit_hash
+    then
       if (session.modified and session.modified.relative == file_path) or (session.original and session.original.relative == file_path) then
         return
       end

--- a/lua/codediff/ui/lifecycle/cleanup.lua
+++ b/lua/codediff/ui/lifecycle/cleanup.lua
@@ -130,11 +130,14 @@ local function cleanup_diff(tabpage)
   active_diffs[tabpage] = nil
 end
 
--- Count windows in current tabpage that have diff markers
-local function count_diff_windows()
+-- Count windows in a tabpage that have diff markers
+local function count_diff_windows(tabpage)
+  if not tabpage or not vim.api.nvim_tabpage_is_valid(tabpage) then
+    return 0
+  end
+
   local count = 0
-  for i = 1, vim.fn.winnr("$") do
-    local win = vim.fn.win_getid(i)
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(tabpage)) do
     if vim.w[win].codediff_restore then
       count = count + 1
     end
@@ -145,6 +148,44 @@ end
 -- Check if we should trigger cleanup for a window
 local function should_cleanup(winid)
   return vim.w[winid].codediff_restore and vim.api.nvim_win_is_valid(winid)
+end
+
+local function has_usable_panel(tabpage, diff)
+  if diff.mode ~= "explorer" and diff.mode ~= "history" then
+    return false
+  end
+
+  local panel = diff.explorer
+  if
+    not panel
+    or panel.is_hidden
+    or type(panel.on_file_select) ~= "function"
+    or not panel.winid
+    or not vim.api.nvim_win_is_valid(panel.winid)
+    or not panel.bufnr
+    or not vim.api.nvim_buf_is_valid(panel.bufnr)
+  then
+    return false
+  end
+
+  return vim.api.nvim_win_get_tabpage(panel.winid) == tabpage and vim.api.nvim_win_get_buf(panel.winid) == panel.bufnr
+end
+
+local function cleanup_threshold(tabpage, diff)
+  local has_result = diff.result_win and vim.api.nvim_win_is_valid(diff.result_win)
+
+  -- A visible panel is still an entry point into a side-by-side session. Keep
+  -- its state even with no diff panes so the next selection can rebuild them.
+  if diff.layout ~= "inline" and not has_result and has_usable_panel(tabpage, diff) then
+    return -1
+  end
+
+  local is_single_window = diff.single_pane == true or diff.layout == "inline"
+  if is_single_window then
+    return 0
+  end
+
+  return 1
 end
 
 -- Setup autocmds for automatic cleanup
@@ -164,11 +205,8 @@ function M.setup_autocmds()
         local active_diffs = session.get_active_diffs()
         for tabpage, diff in pairs(active_diffs) do
           if diff.original_win == closed_win or diff.modified_win == closed_win then
-            -- single_pane/inline mode: we expect only 1 diff window
-            local is_single_window = diff.single_pane == true or diff.layout == "inline"
-            local diff_win_count = count_diff_windows()
-            local threshold = is_single_window and 0 or 1
-            if diff_win_count <= threshold then
+            local diff_win_count = count_diff_windows(tabpage)
+            if diff_win_count <= cleanup_threshold(tabpage, diff) then
               cleanup_diff(tabpage)
             end
             break
@@ -217,10 +255,8 @@ function M.setup_autocmds()
         end
         local diff = session.get_active_diffs()[tabpage]
         if diff then
-          local diff_win_count = count_diff_windows()
-          local is_single_window = diff.single_pane == true or diff.layout == "inline"
-          local threshold = is_single_window and 0 or 1
-          if diff_win_count <= threshold then
+          local diff_win_count = count_diff_windows(tabpage)
+          if diff_win_count <= cleanup_threshold(tabpage, diff) then
             cleanup_diff(tabpage)
           end
         end

--- a/lua/codediff/ui/lifecycle/cleanup.lua
+++ b/lua/codediff/ui/lifecycle/cleanup.lua
@@ -107,11 +107,14 @@ local function cleanup_diff(tabpage)
   active_diffs[tabpage] = nil
 end
 
--- Count windows in current tabpage that have diff markers
-local function count_diff_windows()
+-- Count windows in a tabpage that have diff markers
+local function count_diff_windows(tabpage)
+  if not tabpage or not vim.api.nvim_tabpage_is_valid(tabpage) then
+    return 0
+  end
+
   local count = 0
-  for i = 1, vim.fn.winnr("$") do
-    local win = vim.fn.win_getid(i)
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(tabpage)) do
     if vim.w[win].codediff_restore then
       count = count + 1
     end
@@ -122,6 +125,44 @@ end
 -- Check if we should trigger cleanup for a window
 local function should_cleanup(winid)
   return vim.w[winid].codediff_restore and vim.api.nvim_win_is_valid(winid)
+end
+
+local function has_usable_panel(tabpage, diff)
+  if not diff.panel or (diff.panel.name ~= "explorer" and diff.panel.name ~= "history") then
+    return false
+  end
+
+  local panel = diff.panel.view
+  if
+    not panel
+    or panel.is_hidden
+    or type(panel.on_file_select) ~= "function"
+    or not panel.winid
+    or not vim.api.nvim_win_is_valid(panel.winid)
+    or not panel.bufnr
+    or not vim.api.nvim_buf_is_valid(panel.bufnr)
+  then
+    return false
+  end
+
+  return vim.api.nvim_win_get_tabpage(panel.winid) == tabpage and vim.api.nvim_win_get_buf(panel.winid) == panel.bufnr
+end
+
+local function cleanup_threshold(tabpage, diff)
+  local has_result = diff.result_win and vim.api.nvim_win_is_valid(diff.result_win)
+
+  -- A visible panel is still an entry point into a side-by-side session. Keep
+  -- its state even with no diff panes so the next selection can rebuild them.
+  if diff.layout ~= "inline" and not has_result and has_usable_panel(tabpage, diff) then
+    return -1
+  end
+
+  local is_single_window = diff.single_pane == true or diff.layout == "inline"
+  if is_single_window then
+    return 0
+  end
+
+  return 1
 end
 
 -- Setup autocmds for automatic cleanup
@@ -141,11 +182,8 @@ function M.setup_autocmds()
         local active_diffs = session.get_active_diffs()
         for tabpage, diff in pairs(active_diffs) do
           if diff.original_win == closed_win or diff.modified_win == closed_win then
-            -- single_pane/inline mode: we expect only 1 diff window
-            local is_single_window = diff.single_pane == true or diff.layout == "inline"
-            local diff_win_count = count_diff_windows()
-            local threshold = is_single_window and 0 or 1
-            if diff_win_count <= threshold then
+            local diff_win_count = count_diff_windows(tabpage)
+            if diff_win_count <= cleanup_threshold(tabpage, diff) then
               cleanup_diff(tabpage)
             end
             break
@@ -194,10 +232,8 @@ function M.setup_autocmds()
         end
         local diff = session.get_active_diffs()[tabpage]
         if diff then
-          local diff_win_count = count_diff_windows()
-          local is_single_window = diff.single_pane == true or diff.layout == "inline"
-          local threshold = is_single_window and 0 or 1
-          if diff_win_count <= threshold then
+          local diff_win_count = count_diff_windows(tabpage)
+          if diff_win_count <= cleanup_threshold(tabpage, diff) then
             cleanup_diff(tabpage)
           end
         end

--- a/lua/codediff/ui/view/helpers.lua
+++ b/lua/codediff/ui/view/helpers.lua
@@ -1,8 +1,56 @@
--- Buffer preparation helpers for diff view
+-- Buffer and window helpers for diff views
 local M = {}
 
 local virtual_file = require("codediff.core.virtual_file")
 local path = require("codediff.core.path")
+
+--- True when every pane needed by the current view is still open.
+---@param session table
+---@return boolean
+function M.has_visible_panes(session)
+  local original = session.original_win and vim.api.nvim_win_is_valid(session.original_win) or false
+  local modified = session.modified_win and vim.api.nvim_win_is_valid(session.modified_win) or false
+  if session.single_pane or session.layout == "inline" then
+    return original or modified
+  end
+  return original and modified
+end
+
+--- Open the first content pane when only an explorer or history panel remains.
+---@param tabpage number
+---@param session table
+---@return number? win
+function M.open_pane_from_panel(tabpage, session)
+  local panel = session.panel
+  local view = panel and panel.view
+  local win = view and view.winid
+  if not win or view.is_hidden or not vim.api.nvim_win_is_valid(win) or vim.api.nvim_win_get_tabpage(win) ~= tabpage or vim.api.nvim_win_get_buf(win) ~= view.bufnr then
+    return nil
+  end
+
+  local config = require("codediff.config")
+  local panel_config = config.options[panel.name] or {}
+  local position = panel_config.position or (panel.name == "history" and "bottom" or "left")
+  vim.api.nvim_set_current_win(win)
+  local scratch = vim.api.nvim_create_buf(false, true)
+  vim.bo[scratch].buftype = "nofile"
+  vim.bo[scratch].bufhidden = "wipe"
+
+  local ok, content_win = pcall(vim.api.nvim_open_win, scratch, true, {
+    split = position == "bottom" and "above" or "right",
+    win = -1,
+  })
+  if not ok then
+    pcall(vim.api.nvim_buf_delete, scratch, { force = true })
+    return nil
+  end
+
+  vim.w[content_win].codediff_restore = 1
+  vim.wo[content_win].cursorline = true
+  vim.wo[content_win].wrap = false
+  vim.wo[content_win].list = false
+  return content_win
+end
 
 --- True when the panel opens before any file is chosen, so the panes start
 --- empty and the panel fills them on first selection.

--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -412,8 +412,41 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
   if not old_original_buf or not old_modified_buf then
     return false
   end
-  if not original_win and not modified_win then
-    return false
+  local original_win_valid = original_win and vim.api.nvim_win_is_valid(original_win)
+  local modified_win_valid = modified_win and vim.api.nvim_win_is_valid(modified_win)
+
+  -- If the panel is the only remaining window, recreate the first diff pane
+  -- beside/above it. The normal split path below can then recreate the other
+  -- pane while preserving original_position.
+  if not original_win_valid and not modified_win_valid then
+    local panel_state = session.explorer
+    local panel_win = panel_state and panel_state.winid
+    if not panel_win or panel_state.is_hidden or not vim.api.nvim_win_is_valid(panel_win) or vim.api.nvim_win_get_tabpage(panel_win) ~= tabpage then
+      return false
+    end
+
+    vim.api.nvim_set_current_win(panel_win)
+
+    local panel_config = session.mode == "history" and (config.options.history or {}) or (config.options.explorer or {})
+    local panel_position = panel_config.position or (session.mode == "history" and "bottom" or "left")
+    local content_split = panel_position == "bottom" and "above" or "right"
+    local scratch = vim.api.nvim_create_buf(false, true)
+    vim.bo[scratch].buftype = "nofile"
+    vim.bo[scratch].bufhidden = "wipe"
+
+    local ok, recreated_win = pcall(vim.api.nvim_open_win, scratch, true, {
+      split = content_split,
+      win = -1,
+    })
+    if not ok then
+      pcall(vim.api.nvim_buf_delete, scratch, { force = true })
+      return false
+    end
+
+    original_win = recreated_win
+    original_win_valid = true
+    session.original_win = original_win
+    vim.w[original_win].codediff_restore = 1
   end
 
   -- Disable auto-refresh temporarily
@@ -434,19 +467,20 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
     lifecycle.set_result(tabpage, nil, nil)
   end
 
-  -- Restore second window if returning from single-pane mode
-  if session.single_pane then
+  -- Restore the second window when returning from single-pane mode or when
+  -- either side was manually closed.
+  if session.single_pane or not original_win_valid or not modified_win_valid then
     local split_cmd = config.options.diff.original_position == "right" and "leftabove vsplit" or "rightbelow vsplit"
 
-    if not original_win or not vim.api.nvim_win_is_valid(original_win) then
-      -- Original was closed (untracked file) — recreate it to the left of modified
+    if not original_win_valid then
+      -- Recreate original on the configured side of modified
       vim.api.nvim_set_current_win(modified_win)
       vim.cmd(config.options.diff.original_position == "right" and "rightbelow vsplit" or "leftabove vsplit")
       original_win = vim.api.nvim_get_current_win()
       vim.w[original_win].codediff_restore = 1
       session.original_win = original_win
-    elseif not modified_win or not vim.api.nvim_win_is_valid(modified_win) then
-      -- Modified was closed (deleted file) — recreate it to the right of original
+    elseif not modified_win_valid then
+      -- Recreate modified on the configured side of original
       vim.api.nvim_set_current_win(original_win)
       vim.cmd(split_cmd)
       modified_win = vim.api.nvim_get_current_win()

--- a/lua/codediff/ui/view/side_by_side/single_file.lua
+++ b/lua/codediff/ui/view/side_by_side/single_file.lua
@@ -99,6 +99,10 @@ local function show_single_file(tabpage, opts)
     close_win = nil
   end
 
+  if not keep_win or not vim.api.nvim_win_is_valid(keep_win) then
+    keep_win = helpers.open_pane_from_panel(tabpage, session)
+  end
+
   -- Load the file into the kept window BEFORE closing the other one. Virtual
   -- buffers (from load_virtual_file) carry `bufhidden = "wipe"` so they get
   -- wiped as soon as they have no window; closing close_win first would leave

--- a/lua/codediff/ui/view/side_by_side/update.lua
+++ b/lua/codediff/ui/view/side_by_side/update.lua
@@ -129,8 +129,17 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
   if not old_original_buf or not old_modified_buf then
     return false
   end
-  if not original_win and not modified_win then
-    return false
+  local original_win_valid = original_win and vim.api.nvim_win_is_valid(original_win)
+  local modified_win_valid = modified_win and vim.api.nvim_win_is_valid(modified_win)
+
+  -- Rebuild the first pane from the panel when both diff windows are gone.
+  if not original_win_valid and not modified_win_valid then
+    original_win = helpers.open_pane_from_panel(tabpage, session)
+    if not original_win then
+      return false
+    end
+    original_win_valid = true
+    session.original_win = original_win
   end
 
   -- Disable auto-refresh temporarily
@@ -155,19 +164,19 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
     lifecycle.set_result(tabpage, nil, nil)
   end
 
-  -- Restore second window if returning from single-pane mode
-  if session.single_pane then
+  -- Restore the second pane after a single-file view or a manual close.
+  if session.single_pane or not original_win_valid or not modified_win_valid then
     local split_cmd = config.options.diff.original_position == "right" and "leftabove vsplit" or "rightbelow vsplit"
 
-    if not original_win or not vim.api.nvim_win_is_valid(original_win) then
-      -- Original was closed (untracked file) — recreate it to the left of modified
+    if not original_win_valid then
+      -- Recreate original on the configured side of modified.
       vim.api.nvim_set_current_win(modified_win)
       vim.cmd(config.options.diff.original_position == "right" and "rightbelow vsplit" or "leftabove vsplit")
       original_win = vim.api.nvim_get_current_win()
       vim.w[original_win].codediff_restore = 1
       session.original_win = original_win
-    elseif not modified_win or not vim.api.nvim_win_is_valid(modified_win) then
-      -- Modified was closed (deleted file) — recreate it to the right of original
+    elseif not modified_win_valid then
+      -- Recreate modified on the configured side of original.
       vim.api.nvim_set_current_win(original_win)
       vim.cmd(split_cmd)
       modified_win = vim.api.nvim_get_current_win()

--- a/tests/ui/explorer/explorer_spec.lua
+++ b/tests/ui/explorer/explorer_spec.lua
@@ -321,6 +321,129 @@ describe("Explorer Mode", function()
     assert.is_true(has_explorer, "Should have explorer window")
   end)
 
+  it("Recreates manually closed diff windows when another file is selected", function()
+    local lifecycle = require("codediff.ui.lifecycle")
+    vim.wait(200)
+    lifecycle.cleanup_all()
+
+    vim.fn.writefile({ "modified nested" }, temp_dir .. "/nested/deep.txt")
+    vim.cmd("edit " .. temp_dir .. "/file1.txt")
+    vim.cmd("CodeDiff")
+
+    local tabpage
+    local session
+    local explorer
+    local ready = vim.wait(6000, function()
+      for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+        local candidate = lifecycle.get_session(tp)
+        local candidate_explorer = candidate and candidate.explorer
+        if
+          candidate_explorer
+          and candidate_explorer.current_file_path ~= nil
+          and candidate.original_win
+          and candidate.modified_win
+          and vim.api.nvim_win_is_valid(candidate.original_win)
+          and vim.api.nvim_win_is_valid(candidate.modified_win)
+        then
+          tabpage = tp
+          session = candidate
+          explorer = candidate_explorer
+          return true
+        end
+      end
+      return false
+    end, 20)
+    assert.is_true(ready, "Explorer diff should be ready")
+
+    local target_line
+    local target_path
+    for line = 1, vim.api.nvim_buf_line_count(explorer.bufnr) do
+      local node = explorer.tree:get_node(line)
+      if node and node.data and node.data.path and node.data.path ~= explorer.current_file_path and node.data.status == "M" then
+        target_line = line
+        target_path = node.data.path
+        break
+      end
+    end
+    assert.is_not_nil(target_line, "Should find another modified file")
+
+    local closed_win = session.modified_win
+    vim.api.nvim_set_current_win(closed_win)
+    vim.cmd("close")
+    vim.wait(200)
+
+    assert.is_false(vim.api.nvim_win_is_valid(closed_win), "Modified window should be closed")
+    assert.is_not_nil(lifecycle.get_session(tabpage), "Explorer session should survive one closed diff window")
+    assert.is_true(vim.api.nvim_win_is_valid(explorer.winid), "Explorer window should remain open")
+
+    vim.api.nvim_set_current_win(explorer.winid)
+    vim.api.nvim_win_set_cursor(explorer.winid, { target_line, 0 })
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, false, true), "tx", false)
+
+    local repaired = vim.wait(6000, function()
+      session = lifecycle.get_session(tabpage)
+      if
+        not session
+        or not session.original_win
+        or not session.modified_win
+        or not vim.api.nvim_win_is_valid(session.original_win)
+        or not vim.api.nvim_win_is_valid(session.modified_win)
+      then
+        return false
+      end
+      return session.modified.relative == target_path
+    end, 20)
+
+    assert.is_true(repaired, "Selecting another file should recreate both diff windows")
+    assert.is_true(vim.api.nvim_win_is_valid(explorer.winid), "Explorer should be preserved after repair")
+    assert.equals(3, #vim.api.nvim_tabpage_list_wins(tabpage), "Explorer and two diff windows should be open")
+
+    local next_line
+    local next_path
+    for line = 1, vim.api.nvim_buf_line_count(explorer.bufnr) do
+      local node = explorer.tree:get_node(line)
+      if node and node.data and node.data.path and node.data.path ~= explorer.current_file_path and node.data.status == "M" then
+        next_line = line
+        next_path = node.data.path
+        break
+      end
+    end
+    assert.is_not_nil(next_line, "Should find a file to select after both panes close")
+
+    local closed_original = session.original_win
+    local closed_modified = session.modified_win
+    vim.api.nvim_win_close(closed_original, false)
+    vim.api.nvim_win_close(closed_modified, false)
+    vim.wait(200)
+
+    assert.is_false(vim.api.nvim_win_is_valid(closed_original), "Original window should be closed")
+    assert.is_false(vim.api.nvim_win_is_valid(closed_modified), "Modified window should be closed")
+    assert.is_not_nil(lifecycle.get_session(tabpage), "Explorer session should survive both closed diff windows")
+    assert.is_true(vim.api.nvim_win_is_valid(explorer.winid), "Explorer should be the remaining window")
+
+    vim.api.nvim_set_current_win(explorer.winid)
+    vim.api.nvim_win_set_cursor(explorer.winid, { next_line, 0 })
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, false, true), "tx", false)
+
+    local both_repaired = vim.wait(6000, function()
+      session = lifecycle.get_session(tabpage)
+      if
+        not session
+        or not session.original_win
+        or not session.modified_win
+        or not vim.api.nvim_win_is_valid(session.original_win)
+        or not vim.api.nvim_win_is_valid(session.modified_win)
+      then
+        return false
+      end
+      return session.modified.relative == next_path
+    end, 20)
+
+    assert.is_true(both_repaired, "Selecting another file should recreate both closed diff windows")
+    assert.is_true(vim.api.nvim_win_is_valid(explorer.winid), "Explorer should remain open after both panes are repaired")
+    assert.equals(3, #vim.api.nvim_tabpage_list_wins(tabpage), "Explorer and both recreated diff windows should be open")
+  end)
+
   -- Test 4: Window widths are properly distributed
   it("Distributes window widths correctly", function()
     vim.o.columns = 160  -- Set known terminal width

--- a/tests/ui/explorer/explorer_spec.lua
+++ b/tests/ui/explorer/explorer_spec.lua
@@ -321,7 +321,178 @@ describe("Explorer Mode", function()
     assert.is_true(has_explorer, "Should have explorer window")
   end)
 
+  it("Recreates manually closed diff windows when another file is selected", function()
+    local lifecycle = require("codediff.ui.lifecycle")
+    vim.wait(200)
+    lifecycle.cleanup_all()
+
+    vim.fn.writefile({ "modified nested" }, temp_dir .. "/nested/deep.txt")
+    vim.cmd("edit " .. temp_dir .. "/file1.txt")
+    vim.cmd("CodeDiff")
+
+    local tabpage
+    local session
+    local explorer
+    local ready = vim.wait(6000, function()
+      for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+        local candidate = lifecycle.get_session(tp)
+        local candidate_explorer = lifecycle.get_panel_view(tp)
+        if
+          candidate_explorer
+          and candidate_explorer.current_file_path ~= nil
+          and candidate.original_win
+          and candidate.modified_win
+          and vim.api.nvim_win_is_valid(candidate.original_win)
+          and vim.api.nvim_win_is_valid(candidate.modified_win)
+        then
+          tabpage = tp
+          session = candidate
+          explorer = candidate_explorer
+          return true
+        end
+      end
+      return false
+    end, 20)
+    assert.is_true(ready, "Explorer diff should be ready")
+
+    local target_line
+    local target_path
+    for line = 1, vim.api.nvim_buf_line_count(explorer.bufnr) do
+      local node = explorer.tree:get_node(line)
+      if node and node.data and node.data.path and node.data.path ~= explorer.current_file_path and node.data.status == "M" then
+        target_line = line
+        target_path = node.data.path
+        break
+      end
+    end
+    assert.is_not_nil(target_line, "Should find another modified file")
+
+    local closed_win = session.modified_win
+    vim.api.nvim_set_current_win(closed_win)
+    vim.cmd("close")
+    vim.wait(200)
+
+    assert.is_false(vim.api.nvim_win_is_valid(closed_win), "Modified window should be closed")
+    assert.is_not_nil(lifecycle.get_session(tabpage), "Explorer session should survive one closed diff window")
+    assert.is_true(vim.api.nvim_win_is_valid(explorer.winid), "Explorer window should remain open")
+
+    vim.api.nvim_set_current_win(explorer.winid)
+    vim.api.nvim_win_set_cursor(explorer.winid, { target_line, 0 })
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, false, true), "tx", false)
+
+    local repaired = vim.wait(6000, function()
+      session = lifecycle.get_session(tabpage)
+      if
+        not session
+        or not session.original_win
+        or not session.modified_win
+        or not vim.api.nvim_win_is_valid(session.original_win)
+        or not vim.api.nvim_win_is_valid(session.modified_win)
+      then
+        return false
+      end
+      return session.modified.relative == target_path
+    end, 20)
+
+    assert.is_true(repaired, "Selecting another file should recreate both diff windows")
+    assert.is_true(vim.api.nvim_win_is_valid(explorer.winid), "Explorer should be preserved after repair")
+    assert.equals(3, #vim.api.nvim_tabpage_list_wins(tabpage), "Explorer and two diff windows should be open")
+
+    local next_line
+    local next_path
+    for line = 1, vim.api.nvim_buf_line_count(explorer.bufnr) do
+      local node = explorer.tree:get_node(line)
+      if node and node.data and node.data.path and node.data.path ~= explorer.current_file_path and node.data.status == "M" then
+        next_line = line
+        next_path = node.data.path
+        break
+      end
+    end
+    assert.is_not_nil(next_line, "Should find a file to select after both panes close")
+
+    local closed_original = session.original_win
+    local closed_modified = session.modified_win
+    vim.api.nvim_win_close(closed_original, false)
+    vim.api.nvim_win_close(closed_modified, false)
+    vim.wait(200)
+
+    assert.is_false(vim.api.nvim_win_is_valid(closed_original), "Original window should be closed")
+    assert.is_false(vim.api.nvim_win_is_valid(closed_modified), "Modified window should be closed")
+    assert.is_not_nil(lifecycle.get_session(tabpage), "Explorer session should survive both closed diff windows")
+    assert.is_true(vim.api.nvim_win_is_valid(explorer.winid), "Explorer should be the remaining window")
+
+    vim.api.nvim_set_current_win(explorer.winid)
+    vim.api.nvim_win_set_cursor(explorer.winid, { next_line, 0 })
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, false, true), "tx", false)
+
+    local both_repaired = vim.wait(6000, function()
+      session = lifecycle.get_session(tabpage)
+      if
+        not session
+        or not session.original_win
+        or not session.modified_win
+        or not vim.api.nvim_win_is_valid(session.original_win)
+        or not vim.api.nvim_win_is_valid(session.modified_win)
+      then
+        return false
+      end
+      return session.modified.relative == next_path
+    end, 20)
+
+    assert.is_true(both_repaired, "Selecting another file should recreate both closed diff windows")
+    assert.is_true(vim.api.nvim_win_is_valid(explorer.winid), "Explorer should remain open after both panes are repaired")
+    assert.equals(3, #vim.api.nvim_tabpage_list_wins(tabpage), "Explorer and both recreated diff windows should be open")
+  end)
+
   -- Test 4: Window widths are properly distributed
+  for _, closed_side in ipairs({ "original", "modified", "both" }) do
+    it("Reopens the same file after closing " .. closed_side .. " panes", function()
+      local explorer, session = open_initial_explorer(temp_dir, "list")
+      assert.is_true(h.wait_for_diff_ready())
+      if closed_side ~= "modified" then
+        vim.api.nvim_win_close(session.original_win, false)
+      end
+      if closed_side ~= "original" then
+        vim.api.nvim_win_close(session.modified_win, false)
+      end
+      vim.wait(100)
+
+      explorer.on_file_select(vim.deepcopy(explorer.current_selection))
+      assert.is_true(vim.wait(2000, function()
+        return session.original_win and vim.api.nvim_win_is_valid(session.original_win)
+          and session.modified_win and vim.api.nvim_win_is_valid(session.modified_win)
+      end, 10), "Selecting the same file must restore its panes")
+      assert.is_true(h.wait_for_diff_ready())
+      assert.equals(3, #vim.api.nvim_tabpage_list_wins(explorer.tabpage))
+    end)
+  end
+
+  for _, target in ipairs({
+    { path = "file3.txt", status = "??", group = "unstaged", side = "modified", content = "untracked" },
+    { path = "file2.txt", status = "A", group = "staged", side = "modified", content = "new file" },
+    { path = "nested/deep.txt", status = "D", group = "unstaged", side = "original", content = "original nested" },
+  }) do
+    it("Opens a " .. target.status .. " file after both panes close", function()
+      local explorer, session = open_initial_explorer(temp_dir, "list")
+      assert.is_true(h.wait_for_diff_ready())
+      if target.status == "D" then
+        vim.fn.delete(temp_dir .. "/" .. target.path)
+      end
+      vim.api.nvim_win_close(session.original_win, false)
+      vim.api.nvim_win_close(session.modified_win, false)
+      vim.wait(100)
+
+      explorer.on_file_select(target)
+      assert.is_true(vim.wait(2000, function()
+        local win = session[target.side .. "_win"]
+        return win and vim.api.nvim_win_is_valid(win)
+          and vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(win), 0, 1, false)[1] == target.content
+      end, 10), "Selection must restore a pane with the file content")
+      assert.equals(2, #vim.api.nvim_tabpage_list_wins(explorer.tabpage))
+      assert.equals(target.side, session.single_side)
+    end)
+  end
+
   it("Distributes window widths correctly", function()
     vim.o.columns = 160  -- Set known terminal width
     
@@ -678,4 +849,3 @@ describe("Explorer Mode", function()
     end
   end)
 end)
-

--- a/tests/ui/history/history_layout_spec.lua
+++ b/tests/ui/history/history_layout_spec.lua
@@ -32,6 +32,57 @@ describe("History layout", function()
     end
   end)
 
+  for _, position in ipairs({ "left", "bottom" }) do
+    for _, original_position in ipairs({ "left", "right" }) do
+      it("restores panes with history " .. position .. " and original " .. original_position, function()
+        require("codediff").setup({
+          diff = { layout = "side-by-side", original_position = original_position },
+          history = { position = position },
+        })
+        vim.cmd("CodeDiff history")
+        local lifecycle = require("codediff.ui.lifecycle")
+        local tabpage, session, history
+        assert.is_true(vim.wait(5000, function()
+          tabpage = vim.api.nvim_get_current_tabpage()
+          session = lifecycle.get_session(tabpage)
+          history = lifecycle.get_panel_view(tabpage)
+          return session and history and history.current_selection and session.stored_diff_result
+            and session.original_revision ~= nil
+        end, 10))
+        local selection = vim.deepcopy(history.current_selection)
+        for _, closed_side in ipairs({ "original", "modified", "both" }) do
+          if closed_side ~= "modified" then
+            vim.api.nvim_win_close(session.original_win, false)
+          end
+          if closed_side ~= "original" then
+            vim.api.nvim_win_close(session.modified_win, false)
+          end
+          vim.wait(100)
+          assert.equals(session, lifecycle.get_session(tabpage))
+          vim.api.nvim_set_current_win(history.winid)
+          history.on_file_select(selection)
+          assert.is_true(vim.wait(2000, function()
+            return session.original_win and vim.api.nvim_win_is_valid(session.original_win)
+              and session.modified_win and vim.api.nvim_win_is_valid(session.modified_win)
+          end, 10), "History selection must restore the panes")
+          assert.is_true(h.wait_for_diff_ready())
+          assert.same({ "version 2" }, vim.api.nvim_buf_get_lines(session.original_bufnr, 0, -1, false))
+          assert.same({ "version 3" }, vim.api.nvim_buf_get_lines(session.modified_bufnr, 0, -1, false))
+          assert.equals(3, #vim.api.nvim_tabpage_list_wins(tabpage))
+          local orig_pos = vim.api.nvim_win_get_position(session.original_win)
+          local mod_pos = vim.api.nvim_win_get_position(session.modified_win)
+          local panel_pos = vim.api.nvim_win_get_position(history.winid)
+          assert.equals(original_position == "left", orig_pos[2] < mod_pos[2])
+          if position == "bottom" then
+            assert.is_true(panel_pos[1] > orig_pos[1] and panel_pos[1] > mod_pos[1])
+          else
+            assert.is_true(panel_pos[2] < orig_pos[2] and panel_pos[2] < mod_pos[2])
+          end
+        end
+      end)
+    end
+  end
+
   it("opens a history panel at the bottom with commit content", function()
     vim.cmd("CodeDiff history")
 

--- a/tests/ui/lifecycle/lifecycle_spec.lua
+++ b/tests/ui/lifecycle/lifecycle_spec.lua
@@ -5,6 +5,122 @@ local lifecycle = require("codediff.ui.lifecycle")
 local highlights = require("codediff.ui.highlights")
 local diff = require('codediff.core.diff')
 
+describe("Automatic pane cleanup", function()
+  local function create_session(with_panel, layout)
+    vim.cmd("tabnew")
+    local tabpage = vim.api.nvim_get_current_tabpage()
+    local original_win = vim.api.nvim_get_current_win()
+    local original_buf = vim.api.nvim_create_buf(false, true)
+    local modified_buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_win_set_buf(original_win, original_buf)
+    vim.cmd("vsplit")
+    local modified_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_buf(modified_win, modified_buf)
+    lifecycle.create_session(tabpage, {
+      original = "original.txt",
+      modified = "modified.txt",
+      panel = with_panel and { name = "explorer" } or nil,
+    }, {
+      original_bufnr = original_buf,
+      modified_bufnr = modified_buf,
+      original_win = original_win,
+      modified_win = modified_win,
+      lines_diff = { changes = {}, moves = {} },
+    })
+    lifecycle.update_layout(tabpage, layout or "side-by-side")
+    local session = lifecycle.get_session(tabpage)
+    if with_panel then
+      vim.cmd("vsplit")
+      local panel_buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_win_set_buf(0, panel_buf)
+      lifecycle.set_panel_view(tabpage, {
+        winid = vim.api.nvim_get_current_win(),
+        bufnr = panel_buf,
+        on_file_select = function() end,
+      })
+    end
+    return tabpage, session
+  end
+
+  before_each(function()
+    lifecycle.setup()
+  end)
+
+  after_each(function()
+    lifecycle.cleanup_all()
+    vim.cmd("tabnew")
+    vim.cmd("tabonly!")
+    vim.wait(20)
+  end)
+
+  it("counts the owning tab when WinClosed runs after a tab switch", function()
+    local owner, session = create_session(false)
+    local other, other_session = create_session(false)
+    vim.api.nvim_set_current_tabpage(owner)
+    vim.api.nvim_win_close(session.original_win, false)
+    vim.api.nvim_set_current_tabpage(other)
+    assert.is_true(vim.wait(1000, function()
+      return lifecycle.get_session(owner) == nil
+    end, 10), "A different tab's panes must not prevent cleanup")
+    assert.equals(other_session, lifecycle.get_session(other))
+  end)
+
+  it("keeps a panel session when WinClosed runs in another tab", function()
+    local tabpage, session = create_session(true)
+    vim.api.nvim_win_close(session.original_win, false)
+    vim.api.nvim_win_close(session.modified_win, false)
+    vim.cmd("tabnew")
+    vim.wait(100)
+    assert.equals(session, lifecycle.get_session(tabpage))
+    vim.api.nvim_set_current_tabpage(tabpage)
+    vim.api.nvim_exec_autocmds("BufEnter", {})
+    vim.wait(100)
+    assert.equals(session, lifecycle.get_session(tabpage))
+  end)
+
+  for _, unusable in ipairs({ "hidden", "closed", "replaced", "no callback" }) do
+    it("cleans up when the panel is " .. unusable, function()
+      local tabpage, session = create_session(true)
+      local panel = session.panel.view
+      if unusable == "hidden" then
+        panel.is_hidden = true
+      elseif unusable == "closed" then
+        vim.api.nvim_win_close(panel.winid, false)
+      elseif unusable == "replaced" then
+        vim.api.nvim_win_set_buf(panel.winid, vim.api.nvim_create_buf(false, true))
+      else
+        panel.on_file_select = nil
+      end
+      vim.api.nvim_win_close(session.original_win, false)
+      assert.is_true(vim.wait(1000, function()
+        return lifecycle.get_session(tabpage) == nil
+      end, 10))
+    end)
+  end
+
+  it("still cleans up an inline session with a visible panel", function()
+    local tabpage, session = create_session(true, "inline")
+    vim.api.nvim_win_close(session.original_win, false)
+    vim.api.nvim_win_close(session.modified_win, false)
+    assert.is_true(vim.wait(1000, function()
+      return lifecycle.get_session(tabpage) == nil
+    end, 10))
+  end)
+
+  it("still cleans up a merge session when only its result remains", function()
+    local tabpage, session = create_session(true)
+    vim.cmd("split")
+    local result_buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_win_set_buf(0, result_buf)
+    lifecycle.set_result(tabpage, result_buf, vim.api.nvim_get_current_win())
+    vim.api.nvim_win_close(session.original_win, false)
+    vim.api.nvim_win_close(session.modified_win, false)
+    assert.is_true(vim.wait(1000, function()
+      return lifecycle.get_session(tabpage) == nil
+    end, 10))
+  end)
+end)
+
 describe("Render Lifecycle", function()
   before_each(function()
     highlights.setup()


### PR DESCRIPTION
## Summary

Closing a diff pane with `:close` tears down the whole CodeDiff session, even when the explorer or history panel is still open. The panel disappears along with it, so recovering means re-running `:CodeDiff`.

This keeps explorer and history sessions alive when one or both panes are closed manually. The next file selection rebuilds the missing panes.

## Root cause

Both cleanup handlers in `lua/codediff/ui/lifecycle/cleanup.lua` counted windows tagged with the `codediff_restore` window variable and tore the session down at `count <= 1` for two-pane layouts. Two problems:

1. The panel isn't considered. For explorer and history the panel is itself an entry point so losing a pane shouldn't be fatal.
2. `count_diff_windows()` counted the wrong tab. It used `vim.fn.winnr("$")` / `win_getid()`, which are scoped to the *focused* tabpage but the user may have switched tabs before the count runs.

## Changes

`cleanup.lua`: `count_diff_windows(tabpage)` now takes the owning tabpage and iterates `nvim_tabpage_list_wins()`. The duplicated threshold logic moves into `cleanup_threshold()`, which returns `-1` (never auto-cleanup) for side-by-side explorer/history sessions with a usable panel.

`side_by_side.lua`: `M.update()` no longer bails out when both panes are gone.

## Testing

New test in `explorer_spec.lua` covering both paths: close one pane then select a file, then close both panes and select another.

In addition to the added test, I've used this patch as my daily driver for a few days.