### PR TITLE
refactor(view): decompose inline_view, share the wait, fix conflicts in inline tabs

### DIFF
--- a/lua/codediff/ui/view/helpers.lua
+++ b/lua/codediff/ui/view/helpers.lua
@@ -2,6 +2,28 @@
 local M = {}
 
 local virtual_file = require("codediff.core.virtual_file")
+local path = require("codediff.core.path")
+
+--- True when the panel opens before any file is chosen, so the panes start
+--- empty and the panel fills them on first selection.
+--- Shared by both layouts: they disagree about how many panes to open, not
+--- about when there is nothing to show yet.
+--- @param session_config SessionConfig
+--- @return boolean
+function M.is_panel_placeholder(session_config)
+  local panel_cfg = session_config.panel
+  if not panel_cfg then
+    return false
+  end
+  if panel_cfg.name == "history" then
+    return panel_cfg.data ~= nil
+  end
+  if panel_cfg.name == "explorer" then
+    -- Empty paths, or dir mode, which has no git_root but does have panel data.
+    return path.is_empty(session_config.original) or (not session_config.git_root and panel_cfg.data ~= nil)
+  end
+  return false
+end
 
 -- Helper: Check if revision is virtual (commit hash or STAGED)
 -- Virtual: "STAGED" or commit hash | Real: nil or "WORKING"

--- a/lua/codediff/ui/view/init.lua
+++ b/lua/codediff/ui/view/init.lua
@@ -62,6 +62,16 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
     return require("codediff.ui.view.inline_view").update(tabpage, session_config, auto_scroll_to_first_hunk)
   end
 
+  -- A conflicted file forces side-by-side, but the tab may still be shaped for
+  -- inline: one pane, with both sides pointing at it. Handing that to the
+  -- side-by-side code makes it write both sides into the same window, so the
+  -- second overwrites the first and no result pane is ever opened. Reshape the
+  -- tab first; side_by_side.update opens the missing pane itself.
+  local session = lifecycle.get_session(tabpage)
+  if session_config and session_config.conflict and session and session.layout == "inline" then
+    require("codediff.ui.view.toggle").normalize_side_by_side_layout(tabpage)
+  end
+
   return side_by_side.update(tabpage, session_config, auto_scroll_to_first_hunk)
 end
 

--- a/lua/codediff/ui/view/inline_view.lua
+++ b/lua/codediff/ui/view/inline_view.lua
@@ -111,6 +111,30 @@ end
 ---@param filetype? string
 ---@param on_ready? function
 ---@return table|nil
+--- Replace a scratch buffer's contents, restoring its read-only state.
+--- Returns false when the buffer is gone, which is the caller's cue to stop:
+--- the tab may have closed while the fetch was in flight.
+--- @param bufnr number
+--- @param lines string[]
+--- @return boolean
+local function set_scratch_lines(bufnr, lines)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return false
+  end
+  vim.bo[bufnr].modifiable = true
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  vim.bo[bufnr].modifiable = false
+  return true
+end
+
+--- An empty, unlisted, non-file buffer.
+--- @return number
+local function new_scratch()
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.bo[bufnr].buftype = "nofile"
+  return bufnr
+end
+
 --- Options for the single inline pane. No 'list' here: side-by-side sets it
 --- to keep the two panes visually identical, which does not apply to one pane.
 --- @param win number
@@ -161,16 +185,12 @@ end
 --- @param modified_win number
 --- @return number original_bufnr, number modified_bufnr
 local function open_placeholder_pane(tabpage, modified_win)
-  local mod_scratch = vim.api.nvim_create_buf(false, true)
-  vim.bo[mod_scratch].buftype = "nofile"
+  local mod_scratch = new_scratch()
   pcall(vim.api.nvim_buf_set_name, mod_scratch, "CodeDiff " .. tabpage .. ".inline")
   vim.api.nvim_win_set_buf(modified_win, mod_scratch)
   welcome_window.sync(modified_win)
 
-  local orig_scratch = vim.api.nvim_create_buf(false, true)
-  vim.bo[orig_scratch].buftype = "nofile"
-
-  return orig_scratch, mod_scratch
+  return new_scratch(), mod_scratch
 end
 
 --- Show the modified side in the visible pane.
@@ -201,9 +221,7 @@ end
 --- @param is_virtual boolean
 local function load_hidden_original(info, is_virtual)
   if is_virtual and info.needs_edit then
-    local orig_buf = vim.api.nvim_create_buf(false, true)
-    vim.bo[orig_buf].buftype = "nofile"
-    info.bufnr = orig_buf
+    info.bufnr = new_scratch()
   elseif info.needs_edit then
     local bufnr = vim.fn.bufadd(info.target)
     vim.fn.bufload(bufnr)
@@ -250,12 +268,9 @@ local function render_when_loaded(ctx, render)
   local session_config = ctx.session_config
   git.get_file_content(session_config.original_revision, session_config.git_root, session_config.original.relative, function(err, lines)
     vim.schedule(function()
-      if not vim.api.nvim_buf_is_valid(original_info.bufnr) then
+      if not set_scratch_lines(original_info.bufnr, err and {} or lines) then
         return
       end
-      vim.bo[original_info.bufnr].modifiable = true
-      vim.api.nvim_buf_set_lines(original_info.bufnr, 0, -1, false, err and {} or lines)
-      vim.bo[original_info.bufnr].modifiable = false
 
       if ctx.modified_is_virtual then
         render_after_modified_loads(ctx.tabpage, modified_info.bufnr, render)
@@ -395,6 +410,100 @@ end
 -- Update (for explorer/history file switching)
 -- ============================================================================
 
+--- Fetch a revision from git into a scratch buffer, then signal completion.
+--- Signals nothing if the buffer died while the fetch was in flight.
+--- @param revision string
+--- @param git_root string
+--- @param relative string
+--- @param bufnr number
+--- @param done function
+local function fetch_into_scratch(revision, git_root, relative, bufnr, done)
+  require("codediff.core.git").get_file_content(revision, git_root, relative, function(err, lines)
+    vim.schedule(function()
+      if set_scratch_lines(bufnr, err and {} or lines) then
+        done()
+      end
+    end)
+  end)
+end
+
+--- Put the modified side in the pane.
+--- Unlike create, a virtual revision goes into a scratch buffer rather than a
+--- codediff:// URI, so retargeting never races a pending BufReadCmd.
+--- @param win number
+--- @param session_config SessionConfig
+--- @param is_virtual boolean
+--- @return number bufnr
+local function open_modified_for_update(win, session_config, is_virtual)
+  if is_virtual then
+    local mod_buf = new_scratch()
+    vim.bo[mod_buf].modifiable = true
+    vim.api.nvim_win_set_buf(win, mod_buf)
+    local ft = vim.filetype.match({ filename = session_config.modified.absolute })
+    if ft then
+      vim.bo[mod_buf].filetype = ft
+    end
+    return mod_buf
+  end
+
+  local info = prepare_buffer(false, session_config.git_root, nil, session_config.modified)
+  if info.needs_edit then
+    return open_real_file(win, info.target)
+  end
+  show_real_file_buffer(win, info.bufnr)
+  return info.bufnr
+end
+
+--- Fill the hidden original side. A real file is copied in synchronously; a
+--- revision is fetched and lands through `done`.
+--- @param orig_buf number
+--- @param session_config SessionConfig
+--- @param is_virtual boolean
+--- @param done function Called when an async fetch lands
+local function fill_original_for_update(orig_buf, session_config, is_virtual, done)
+  if is_virtual then
+    -- Retargeting can leave the original path empty (a file added in the
+    -- modified revision), so fall back to the modified side's path.
+    local relative = (session_config.original.relative ~= "" and session_config.original.relative) or session_config.modified.relative
+    fetch_into_scratch(session_config.original_revision, session_config.git_root, relative, orig_buf, done)
+    return
+  end
+
+  local orig_path = (session_config.original.absolute ~= "" and session_config.original.absolute) or session_config.modified.absolute
+  if orig_path and orig_path ~= "" then
+    local real_bufnr = vim.fn.bufadd(orig_path)
+    vim.fn.bufload(real_bufnr)
+    set_scratch_lines(orig_buf, vim.api.nvim_buf_get_lines(real_bufnr, 0, -1, false))
+  end
+end
+
+--- Point the session at the newly computed diff and re-arm everything hanging
+--- off it: refresh, keymaps, layout, and the window the user was in.
+--- @param tabpage number
+--- @param session_config SessionConfig
+--- @param orig_buf number
+--- @param mod_buf number
+--- @param lines_diff table
+--- @param saved_current_win number?
+local function commit_update(tabpage, session_config, orig_buf, mod_buf, lines_diff, saved_current_win)
+  lifecycle.update_buffers(tabpage, orig_buf, mod_buf)
+  lifecycle.update_git_root(tabpage, session_config.git_root)
+  lifecycle.update_revisions(tabpage, session_config.original_revision, session_config.modified_revision)
+  lifecycle.update_diff_result(tabpage, lines_diff)
+  lifecycle.update_changedtick(tabpage, vim.api.nvim_buf_get_changedtick(orig_buf), vim.api.nvim_buf_get_changedtick(mod_buf))
+  lifecycle.update_paths(tabpage, session_config.original, session_config.modified)
+
+  auto_refresh.enable(orig_buf)
+  auto_refresh.enable(mod_buf)
+
+  setup_keymaps(tabpage, orig_buf, mod_buf)
+  layout.arrange(tabpage)
+
+  if saved_current_win and vim.api.nvim_win_is_valid(saved_current_win) then
+    vim.api.nvim_set_current_win(saved_current_win)
+  end
+end
+
 ---@param tabpage number
 ---@param session_config SessionConfig
 ---@param auto_scroll_to_first_hunk boolean?
@@ -425,36 +534,13 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
   local original_is_virtual = is_virtual_revision(session_config.original_revision)
   local modified_is_virtual = is_virtual_revision(session_config.modified_revision)
 
-  -- For inline mode, load ALL virtual buffers via git.get_file_content into scratch
-  -- buffers instead of codediff:// URIs (avoids race conditions and bufhidden=wipe)
-
-  local orig_buf = vim.api.nvim_create_buf(false, true)
-  vim.bo[orig_buf].buftype = "nofile"
-
-  local mod_buf
-  if modified_is_virtual then
-    mod_buf = vim.api.nvim_create_buf(false, true)
-    vim.bo[mod_buf].buftype = "nofile"
-    vim.bo[mod_buf].modifiable = true
-    vim.api.nvim_win_set_buf(modified_win, mod_buf)
-    local ft = vim.filetype.match({ filename = session_config.modified.absolute })
-    if ft then
-      vim.bo[mod_buf].filetype = ft
-    end
-  else
-    local modified_info = prepare_buffer(false, session_config.git_root, nil, session_config.modified)
-    if modified_info.needs_edit then
-      mod_buf = open_real_file(modified_win, modified_info.target)
-    else
-      mod_buf = modified_info.bufnr
-      show_real_file_buffer(modified_win, mod_buf)
-    end
-  end
+  local orig_buf = new_scratch()
+  local mod_buf = open_modified_for_update(modified_win, session_config, modified_is_virtual)
   welcome_window.sync(modified_win)
 
   local should_auto_scroll = auto_scroll_to_first_hunk == true
 
-  local render_everything = function()
+  local render = function()
     if not vim.api.nvim_win_is_valid(modified_win) then
       return
     end
@@ -462,97 +548,46 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
       return
     end
 
-    local original_lines = vim.api.nvim_buf_get_lines(orig_buf, 0, -1, false)
-    local modified_lines = vim.api.nvim_buf_get_lines(mod_buf, 0, -1, false)
-
-    local lines_diff = compute_and_render_inline(mod_buf, orig_buf, original_lines, modified_lines, original_is_virtual, modified_is_virtual, modified_win, should_auto_scroll)
-
+    local lines_diff = compute_and_render_inline(
+      mod_buf,
+      orig_buf,
+      vim.api.nvim_buf_get_lines(orig_buf, 0, -1, false),
+      vim.api.nvim_buf_get_lines(mod_buf, 0, -1, false),
+      original_is_virtual,
+      modified_is_virtual,
+      modified_win,
+      should_auto_scroll
+    )
     if lines_diff then
-      lifecycle.update_buffers(tabpage, orig_buf, mod_buf)
-      lifecycle.update_git_root(tabpage, session_config.git_root)
-      lifecycle.update_revisions(tabpage, session_config.original_revision, session_config.modified_revision)
-      lifecycle.update_diff_result(tabpage, lines_diff)
-      lifecycle.update_changedtick(tabpage, vim.api.nvim_buf_get_changedtick(orig_buf), vim.api.nvim_buf_get_changedtick(mod_buf))
-      lifecycle.update_paths(tabpage, session_config.original, session_config.modified)
-
-      auto_refresh.enable(orig_buf)
-      auto_refresh.enable(mod_buf)
-
-      setup_keymaps(tabpage, orig_buf, mod_buf)
-      layout.arrange(tabpage)
-
-      if saved_current_win and vim.api.nvim_win_is_valid(saved_current_win) then
-        vim.api.nvim_set_current_win(saved_current_win)
-      end
+      commit_update(tabpage, session_config, orig_buf, mod_buf, lines_diff, saved_current_win)
     end
   end
 
-  -- Async loading with pending counter
+  -- Each side reports whether it still owes content; the last one to land
+  -- renders. Both may finish synchronously, hence the trailing check.
+  -- Flags are set before the fetches start, never from their return values,
+  -- so a callback can never be overwritten by a late assignment.
   local pending = { original = original_is_virtual, modified = modified_is_virtual }
-  local git = require("codediff.core.git")
-
   local function check_ready()
     if not pending.original and not pending.modified then
-      render_everything()
+      render()
     end
   end
 
-  if original_is_virtual then
-    git.get_file_content(
-      session_config.original_revision,
-      session_config.git_root,
-      (session_config.original.relative ~= "" and session_config.original.relative) or session_config.modified.relative,
-      function(err, lines)
-        vim.schedule(function()
-          if not vim.api.nvim_buf_is_valid(orig_buf) then
-            return
-          end
-          if err then
-            lines = {}
-          end
-          vim.bo[orig_buf].modifiable = true
-          vim.api.nvim_buf_set_lines(orig_buf, 0, -1, false, lines)
-          vim.bo[orig_buf].modifiable = false
-          pending.original = false
-          check_ready()
-        end)
-      end
-    )
-  else
-    local orig_path = (session_config.original.absolute ~= "" and session_config.original.absolute) or session_config.modified.absolute
-    if orig_path and orig_path ~= "" then
-      local real_bufnr = vim.fn.bufadd(orig_path)
-      vim.fn.bufload(real_bufnr)
-      local lines = vim.api.nvim_buf_get_lines(real_bufnr, 0, -1, false)
-      vim.bo[orig_buf].modifiable = true
-      vim.api.nvim_buf_set_lines(orig_buf, 0, -1, false, lines)
-      vim.bo[orig_buf].modifiable = false
-    end
+  fill_original_for_update(orig_buf, session_config, original_is_virtual, function()
     pending.original = false
-  end
+    check_ready()
+  end)
 
   if modified_is_virtual then
-    git.get_file_content(session_config.modified_revision, session_config.git_root, session_config.modified.relative, function(err, lines)
-      vim.schedule(function()
-        if not vim.api.nvim_buf_is_valid(mod_buf) then
-          return
-        end
-        if err then
-          lines = {}
-        end
-        vim.bo[mod_buf].modifiable = true
-        vim.api.nvim_buf_set_lines(mod_buf, 0, -1, false, lines)
-        vim.bo[mod_buf].modifiable = false
-        pending.modified = false
-        check_ready()
-      end)
+    fetch_into_scratch(session_config.modified_revision, session_config.git_root, session_config.modified.relative, mod_buf, function()
+      pending.modified = false
+      check_ready()
     end)
-  else
-    pending.modified = false
   end
 
   if not pending.original and not pending.modified then
-    vim.schedule(render_everything)
+    vim.schedule(render)
   end
 
   return true

--- a/lua/codediff/ui/view/inline_view.lua
+++ b/lua/codediff/ui/view/inline_view.lua
@@ -14,6 +14,7 @@ local layout = require("codediff.ui.layout")
 local welcome_window = require("codediff.ui.view.welcome_window")
 
 local helpers = require("codediff.ui.view.helpers")
+local readiness = require("codediff.ui.view.readiness")
 local panel = require("codediff.ui.view.panel")
 local is_virtual_revision = helpers.is_virtual_revision
 local prepare_buffer = helpers.prepare_buffer
@@ -563,31 +564,28 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
     end
   end
 
-  -- Each side reports whether it still owes content; the last one to land
-  -- renders. Both may finish synchronously, hence the trailing check.
-  -- Flags are set before the fetches start, never from their return values,
-  -- so a callback can never be overwritten by a late assignment.
-  local pending = { original = original_is_virtual, modified = modified_is_virtual }
-  local function check_ready()
-    if not pending.original and not pending.modified then
-      render()
-    end
+  -- Each side reports itself as it lands; the last one triggers the render.
+  -- Sides that are already in hand are simply not awaited.
+  local awaited = {}
+  if original_is_virtual then
+    awaited[#awaited + 1] = "original"
+  end
+  if modified_is_virtual then
+    awaited[#awaited + 1] = "modified"
   end
 
+  local ready = readiness.when_all(awaited, function()
+    vim.schedule(render)
+  end)
+
   fill_original_for_update(orig_buf, session_config, original_is_virtual, function()
-    pending.original = false
-    check_ready()
+    ready.done("original")
   end)
 
   if modified_is_virtual then
     fetch_into_scratch(session_config.modified_revision, session_config.git_root, session_config.modified.relative, mod_buf, function()
-      pending.modified = false
-      check_ready()
+      ready.done("modified")
     end)
-  end
-
-  if not pending.original and not pending.modified then
-    vim.schedule(render)
   end
 
   return true

--- a/lua/codediff/ui/view/inline_view.lua
+++ b/lua/codediff/ui/view/inline_view.lua
@@ -17,6 +17,7 @@ local helpers = require("codediff.ui.view.helpers")
 local panel = require("codediff.ui.view.panel")
 local is_virtual_revision = helpers.is_virtual_revision
 local prepare_buffer = helpers.prepare_buffer
+local is_panel_placeholder = helpers.is_panel_placeholder
 local show_real_file_buffer = helpers.show_real_file_buffer
 local open_real_file = helpers.open_real_file
 
@@ -110,37 +111,185 @@ end
 ---@param filetype? string
 ---@param on_ready? function
 ---@return table|nil
+--- Options for the single inline pane. No 'list' here: side-by-side sets it
+--- to keep the two panes visually identical, which does not apply to one pane.
+--- @param win number
+local function apply_pane_options(win)
+  vim.wo[win].cursorline = true
+  vim.wo[win].wrap = false
+end
+
+--- Reapply-keymaps callback stored on the session.
+--- @param tabpage number
+--- @param original_bufnr number
+--- @return function
+local function make_reapply_keymaps(tabpage, original_bufnr)
+  return function()
+    local _, mb = lifecycle.get_buffers(tabpage)
+    if mb then
+      setup_keymaps(tabpage, original_bufnr, mb)
+    end
+  end
+end
+
+--- Attach the panels, lay the tab out, announce the view, and describe it.
+--- @param tabpage number
+--- @param session_config SessionConfig
+--- @param modified_win number
+--- @param original_bufnr number
+--- @param modified_bufnr number
+--- @return table
+local function finish_create(tabpage, session_config, modified_win, original_bufnr, modified_bufnr)
+  panel.setup_explorer(tabpage, session_config, modified_win, modified_win)
+  panel.setup_history(tabpage, session_config, modified_win, modified_win)
+
+  layout.arrange(tabpage)
+
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "CodeDiffOpen",
+    modeline = false,
+    data = { tabpage = tabpage, mode = lifecycle.event_mode(session_config.panel), layout = "inline" },
+  })
+
+  return { modified_buf = modified_bufnr, original_buf = original_bufnr, modified_win = modified_win }
+end
+
+--- Open the single pane with a scratch buffer, for a session whose content
+--- arrives later via the panel. The hidden original side gets a scratch buffer
+--- too, so the session always has two buffers to talk about.
+--- @param tabpage number
+--- @param modified_win number
+--- @return number original_bufnr, number modified_bufnr
+local function open_placeholder_pane(tabpage, modified_win)
+  local mod_scratch = vim.api.nvim_create_buf(false, true)
+  vim.bo[mod_scratch].buftype = "nofile"
+  pcall(vim.api.nvim_buf_set_name, mod_scratch, "CodeDiff " .. tabpage .. ".inline")
+  vim.api.nvim_win_set_buf(modified_win, mod_scratch)
+  welcome_window.sync(modified_win)
+
+  local orig_scratch = vim.api.nvim_create_buf(false, true)
+  vim.bo[orig_scratch].buftype = "nofile"
+
+  return orig_scratch, mod_scratch
+end
+
+--- Show the modified side in the visible pane.
+--- @param win number
+--- @param info table From prepare_buffer; info.bufnr is updated in place
+--- @param is_virtual boolean
+local function load_visible_side(win, info, is_virtual)
+  if is_virtual then
+    if info.needs_edit then
+      vim.cmd("edit! " .. vim.fn.fnameescape(info.target))
+      info.bufnr = vim.api.nvim_get_current_buf()
+    else
+      vim.api.nvim_win_set_buf(win, info.bufnr)
+    end
+  elseif info.needs_edit then
+    info.bufnr = open_real_file(win, info.target)
+  else
+    show_real_file_buffer(win, info.bufnr)
+  end
+  welcome_window.sync(win)
+end
+
+--- Materialise the original side, which inline never puts in a window.
+--- A virtual original cannot use :edit — codediff:// buffers carry
+--- bufhidden=wipe, so with no window showing them they are destroyed at once.
+--- It gets an empty scratch buffer that the async fetch fills instead.
+--- @param info table From prepare_buffer; info.bufnr is updated in place
+--- @param is_virtual boolean
+local function load_hidden_original(info, is_virtual)
+  if is_virtual and info.needs_edit then
+    local orig_buf = vim.api.nvim_create_buf(false, true)
+    vim.bo[orig_buf].buftype = "nofile"
+    info.bufnr = orig_buf
+  elseif info.needs_edit then
+    local bufnr = vim.fn.bufadd(info.target)
+    vim.fn.bufload(bufnr)
+    info.bufnr = bufnr
+  end
+end
+
+--- Call `render` once the modified buffer's virtual content has loaded.
+--- @param tabpage number
+--- @param modified_bufnr number
+--- @param render function
+local function render_after_modified_loads(tabpage, modified_bufnr, render)
+  local group = vim.api.nvim_create_augroup("CodeDiffInlineVirtualLoad_" .. tabpage, { clear = true })
+  vim.api.nvim_create_autocmd("User", {
+    group = group,
+    pattern = "CodeDiffVirtualFileLoaded",
+    callback = function(event)
+      if event.data and event.data.buf == modified_bufnr then
+        vim.schedule(render)
+        vim.api.nvim_del_augroup_by_id(group)
+      end
+    end,
+  })
+end
+
+--- Run `render` once both sides hold their content.
+--- The original side, when virtual, is fetched here rather than through
+--- BufReadCmd, because it has no window to trigger one.
+--- @param ctx table { tabpage, session_config, original_info, modified_info, virtual flags }
+--- @param render function
+local function render_when_loaded(ctx, render)
+  local original_info, modified_info = ctx.original_info, ctx.modified_info
+
+  if not ctx.original_is_virtual then
+    if ctx.modified_is_virtual then
+      render_after_modified_loads(ctx.tabpage, modified_info.bufnr, render)
+    else
+      vim.schedule(render)
+    end
+    return
+  end
+
+  local git = require("codediff.core.git")
+  local session_config = ctx.session_config
+  git.get_file_content(session_config.original_revision, session_config.git_root, session_config.original.relative, function(err, lines)
+    vim.schedule(function()
+      if not vim.api.nvim_buf_is_valid(original_info.bufnr) then
+        return
+      end
+      vim.bo[original_info.bufnr].modifiable = true
+      vim.api.nvim_buf_set_lines(original_info.bufnr, 0, -1, false, err and {} or lines)
+      vim.bo[original_info.bufnr].modifiable = false
+
+      if ctx.modified_is_virtual then
+        render_after_modified_loads(ctx.tabpage, modified_info.bufnr, render)
+      else
+        render()
+      end
+    end)
+  end)
+end
+
 function M.create(session_config, filetype, on_ready)
-  -- Create new tab
   vim.cmd("tabnew")
   local tabpage = vim.api.nvim_get_current_tabpage()
   local modified_win = vim.api.nvim_get_current_win()
   local initial_buf = vim.api.nvim_get_current_buf()
 
-  -- Check if this is an explorer/history placeholder
-  local is_explorer_placeholder = session_config.panel
-    and session_config.panel.name == "explorer"
-    and (path.is_empty(session_config.original) or (not session_config.git_root and session_config.panel.data))
-  local is_history_placeholder = session_config.panel and session_config.panel.name == "history" and session_config.panel.data
-
-  if is_explorer_placeholder or is_history_placeholder then
-    -- Placeholder: single window with scratch buffer, no diff yet
-    local mod_scratch = vim.api.nvim_create_buf(false, true)
-    vim.bo[mod_scratch].buftype = "nofile"
-    pcall(vim.api.nvim_buf_set_name, mod_scratch, "CodeDiff " .. tabpage .. ".inline")
-    vim.api.nvim_win_set_buf(modified_win, mod_scratch)
-    welcome_window.sync(modified_win)
-
-    local orig_scratch = vim.api.nvim_create_buf(false, true)
-    vim.bo[orig_scratch].buftype = "nofile"
-
-    if vim.api.nvim_buf_is_valid(initial_buf) and initial_buf ~= mod_scratch then
+  --- Drop the tab's starting buffer once the real ones are in place.
+  local function drop_initial_buf(...)
+    for _, keep in ipairs({ ... }) do
+      if initial_buf == keep then
+        return
+      end
+    end
+    if vim.api.nvim_buf_is_valid(initial_buf) then
       pcall(vim.api.nvim_buf_delete, initial_buf, { force = true })
     end
+  end
 
-    vim.wo[modified_win].cursorline = true
-    vim.wo[modified_win].wrap = false
+  if is_panel_placeholder(session_config) then
+    local orig_scratch, mod_scratch = open_placeholder_pane(tabpage, modified_win)
+    drop_initial_buf(mod_scratch)
+    apply_pane_options(modified_win)
 
+    -- The panel populates this session on first file selection.
     lifecycle.create_session(tabpage, {
       panel = session_config.panel,
       merge = session_config.conflict,
@@ -155,73 +304,26 @@ function M.create(session_config, filetype, on_ready)
       modified_win = modified_win, -- both point to the single window
       lines_diff = {},
       exit_on_close = session_config.exit_on_close,
-      reapply_keymaps = function()
-        local _, mb = lifecycle.get_buffers(tabpage)
-        if mb then
-          setup_keymaps(tabpage, orig_scratch, mb)
-        end
-      end,
+      reapply_keymaps = make_reapply_keymaps(tabpage, orig_scratch),
     })
 
     mark_inline(tabpage)
-    -- Setup panels via shared module
-    panel.setup_explorer(tabpage, session_config, modified_win, modified_win)
-    panel.setup_history(tabpage, session_config, modified_win, modified_win)
-
-    layout.arrange(tabpage)
-
-    vim.api.nvim_exec_autocmds("User", {
-      pattern = "CodeDiffOpen",
-      modeline = false,
-      data = { tabpage = tabpage, mode = lifecycle.event_mode(session_config.panel), layout = "inline" },
-    })
-
-    return { modified_buf = mod_scratch, original_buf = orig_scratch, modified_win = modified_win }
+    return finish_create(tabpage, session_config, modified_win, orig_scratch, mod_scratch)
   end
 
-  -- Normal (non-placeholder) inline view creation
   local original_is_virtual = is_virtual_revision(session_config.original_revision)
   local modified_is_virtual = is_virtual_revision(session_config.modified_revision)
 
   local original_info = prepare_buffer(original_is_virtual, session_config.git_root, session_config.original_revision, session_config.original)
   local modified_info = prepare_buffer(modified_is_virtual, session_config.git_root, session_config.modified_revision, session_config.modified)
 
-  -- Load modified buffer into the visible window
-  if modified_is_virtual then
-    if modified_info.needs_edit then
-      vim.cmd("edit! " .. vim.fn.fnameescape(modified_info.target))
-      modified_info.bufnr = vim.api.nvim_get_current_buf()
-    else
-      vim.api.nvim_win_set_buf(modified_win, modified_info.bufnr)
-    end
-  elseif modified_info.needs_edit then
-    modified_info.bufnr = open_real_file(modified_win, modified_info.target)
-  else
-    show_real_file_buffer(modified_win, modified_info.bufnr)
-  end
-  welcome_window.sync(modified_win)
+  load_visible_side(modified_win, modified_info, modified_is_virtual)
+  load_hidden_original(original_info, original_is_virtual)
 
-  -- Load original buffer (hidden — never displayed in a window)
-  if original_is_virtual and original_info.needs_edit then
-    -- Can't use :edit with codediff:// URIs because bufhidden=wipe destroys
-    -- the buffer when no window displays it. Use scratch buffer instead.
-    local orig_buf = vim.api.nvim_create_buf(false, true)
-    vim.bo[orig_buf].buftype = "nofile"
-    original_info.bufnr = orig_buf
-  elseif original_info.needs_edit then
-    local bufnr = vim.fn.bufadd(original_info.target)
-    vim.fn.bufload(bufnr)
-    original_info.bufnr = bufnr
-  end
+  drop_initial_buf(modified_info.bufnr, original_info.bufnr)
+  apply_pane_options(modified_win)
 
-  if vim.api.nvim_buf_is_valid(initial_buf) and initial_buf ~= modified_info.bufnr and initial_buf ~= original_info.bufnr then
-    pcall(vim.api.nvim_buf_delete, initial_buf, { force = true })
-  end
-
-  vim.wo[modified_win].cursorline = true
-  vim.wo[modified_win].wrap = false
-
-  local render_everything = function()
+  local render = function()
     if not vim.api.nvim_win_is_valid(modified_win) then
       return
     end
@@ -229,122 +331,64 @@ function M.create(session_config, filetype, on_ready)
       return
     end
 
-    local original_lines = vim.api.nvim_buf_get_lines(original_info.bufnr, 0, -1, false)
-    local modified_lines = vim.api.nvim_buf_get_lines(modified_info.bufnr, 0, -1, false)
-
     local lines_diff = compute_and_render_inline(
       modified_info.bufnr,
       original_info.bufnr,
-      original_lines,
-      modified_lines,
+      vim.api.nvim_buf_get_lines(original_info.bufnr, 0, -1, false),
+      vim.api.nvim_buf_get_lines(modified_info.bufnr, 0, -1, false),
       original_is_virtual,
       modified_is_virtual,
       modified_win,
       config.options.diff.jump_to_first_change
     )
+    if not lines_diff then
+      return
+    end
 
-    if lines_diff then
-      lifecycle.create_session(tabpage, {
-        panel = session_config.panel,
-        merge = session_config.conflict,
-        git_root = session_config.git_root,
-        original = session_config.original,
-        modified = session_config.modified,
-        original_revision = session_config.original_revision,
-        modified_revision = session_config.modified_revision,
-        original_bufnr = original_info.bufnr,
-        modified_bufnr = modified_info.bufnr,
-        original_win = modified_win,
-        modified_win = modified_win,
-        lines_diff = lines_diff,
-        exit_on_close = session_config.exit_on_close,
-        reapply_keymaps = function()
-          local _, mb = lifecycle.get_buffers(tabpage)
-          if mb then
-            setup_keymaps(tabpage, original_info.bufnr, mb)
-          end
-        end,
-      })
+    lifecycle.create_session(tabpage, {
+      panel = session_config.panel,
+      merge = session_config.conflict,
+      git_root = session_config.git_root,
+      original = session_config.original,
+      modified = session_config.modified,
+      original_revision = session_config.original_revision,
+      modified_revision = session_config.modified_revision,
+      original_bufnr = original_info.bufnr,
+      modified_bufnr = modified_info.bufnr,
+      original_win = modified_win,
+      modified_win = modified_win,
+      lines_diff = lines_diff,
+      exit_on_close = session_config.exit_on_close,
+      reapply_keymaps = make_reapply_keymaps(tabpage, original_info.bufnr),
+    })
 
-      mark_inline(tabpage)
+    mark_inline(tabpage)
 
-      auto_refresh.enable(original_info.bufnr)
-      auto_refresh.enable(modified_info.bufnr)
+    auto_refresh.enable(original_info.bufnr)
+    auto_refresh.enable(modified_info.bufnr)
 
-      setup_keymaps(tabpage, original_info.bufnr, modified_info.bufnr)
+    setup_keymaps(tabpage, original_info.bufnr, modified_info.bufnr)
 
-      -- Keep the diff pointed at the working window's file if it changes.
-      -- Same as the side-by-side path: the behaviour belongs to the session
-      -- shape, not to a layout.
-      require("codediff.ui.follow_working_file").enable(tabpage, original_is_virtual, modified_is_virtual)
+    -- Keep the diff pointed at the working window's file if it changes. Same
+    -- as the side-by-side path: the behaviour belongs to the session shape,
+    -- not to a layout.
+    require("codediff.ui.follow_working_file").enable(tabpage, original_is_virtual, modified_is_virtual)
 
-      if on_ready then
-        on_ready()
-      end
+    if on_ready then
+      on_ready()
     end
   end
 
-  -- Async buffer loading
-  if original_is_virtual then
-    local git = require("codediff.core.git")
-    git.get_file_content(session_config.original_revision, session_config.git_root, session_config.original.relative, function(err, lines)
-      vim.schedule(function()
-        if not vim.api.nvim_buf_is_valid(original_info.bufnr) then
-          return
-        end
-        if err then
-          lines = {}
-        end
-        vim.bo[original_info.bufnr].modifiable = true
-        vim.api.nvim_buf_set_lines(original_info.bufnr, 0, -1, false, lines)
-        vim.bo[original_info.bufnr].modifiable = false
+  render_when_loaded({
+    tabpage = tabpage,
+    session_config = session_config,
+    original_info = original_info,
+    modified_info = modified_info,
+    original_is_virtual = original_is_virtual,
+    modified_is_virtual = modified_is_virtual,
+  }, render)
 
-        if modified_is_virtual then
-          local group = vim.api.nvim_create_augroup("CodeDiffInlineVirtualLoad_" .. tabpage, { clear = true })
-          vim.api.nvim_create_autocmd("User", {
-            group = group,
-            pattern = "CodeDiffVirtualFileLoaded",
-            callback = function(event)
-              if event.data and event.data.buf == modified_info.bufnr then
-                vim.schedule(render_everything)
-                vim.api.nvim_del_augroup_by_id(group)
-              end
-            end,
-          })
-        else
-          render_everything()
-        end
-      end)
-    end)
-  elseif modified_is_virtual then
-    local group = vim.api.nvim_create_augroup("CodeDiffInlineVirtualLoad_" .. tabpage, { clear = true })
-    vim.api.nvim_create_autocmd("User", {
-      group = group,
-      pattern = "CodeDiffVirtualFileLoaded",
-      callback = function(event)
-        if event.data and event.data.buf == modified_info.bufnr then
-          vim.schedule(render_everything)
-          vim.api.nvim_del_augroup_by_id(group)
-        end
-      end,
-    })
-  else
-    vim.schedule(render_everything)
-  end
-
-  -- Setup panels for non-placeholder explorer/history mode
-  panel.setup_explorer(tabpage, session_config, modified_win, modified_win)
-  panel.setup_history(tabpage, session_config, modified_win, modified_win)
-
-  layout.arrange(tabpage)
-
-  vim.api.nvim_exec_autocmds("User", {
-    pattern = "CodeDiffOpen",
-    modeline = false,
-    data = { tabpage = tabpage, mode = lifecycle.event_mode(session_config.panel), layout = "inline" },
-  })
-
-  return { modified_buf = modified_info.bufnr, original_buf = original_info.bufnr, modified_win = modified_win }
+  return finish_create(tabpage, session_config, modified_win, original_info.bufnr, modified_info.bufnr)
 end
 
 -- ============================================================================

--- a/lua/codediff/ui/view/readiness.lua
+++ b/lua/codediff/ui/view/readiness.lua
@@ -1,0 +1,66 @@
+-- Waiting for both sides of a diff to arrive.
+--
+-- A diff needs the original and the modified content together, and each side
+-- arrives on its own schedule: one may come from a git fetch, the other from a
+-- BufReadCmd, and either can finish first. Whichever callback runs last is the
+-- one that must start the render -- but a callback only knows about its own
+-- side, so something has to remember which sides are still outstanding.
+--
+-- That bookkeeping was written out by hand at four call sites, twice under the
+-- name `pending` and twice under `wait_state`. This is that bookkeeping, once.
+
+local M = {}
+
+--- Wait for every named side, then run `on_ready` exactly once.
+---
+--- Names are arbitrary labels; the caller reports each one as it lands. An
+--- empty list means nothing is outstanding, so `on_ready` runs immediately.
+--- Reporting the same name twice, or a name that was never awaited, does
+--- nothing -- so a duplicated event cannot render twice.
+---
+--- @param names string[] Sides to wait for, e.g. { "original", "modified" }
+--- @param on_ready function Run once every name has been reported
+--- @return table waiter With done(name) and pending()
+function M.when_all(names, on_ready)
+  local outstanding = {}
+  local remaining = 0
+  for _, name in ipairs(names) do
+    if not outstanding[name] then
+      outstanding[name] = true
+      remaining = remaining + 1
+    end
+  end
+
+  -- Reporting a name removes it from `outstanding`, so a side can only be
+  -- counted once and this can only reach zero once. No separate "already ran"
+  -- flag: nothing can get past the check above to need one.
+  local function fire_if_ready()
+    if remaining > 0 then
+      return
+    end
+    on_ready()
+  end
+
+  fire_if_ready()
+
+  return {
+    --- Report that `name` has arrived.
+    --- @param name string
+    done = function(name)
+      if not outstanding[name] then
+        return
+      end
+      outstanding[name] = nil
+      remaining = remaining - 1
+      fire_if_ready()
+    end,
+
+    --- True while any awaited side is still outstanding.
+    --- @return boolean
+    pending = function()
+      return remaining > 0
+    end,
+  }
+end
+
+return M

--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -24,6 +24,7 @@ local welcome_window = require("codediff.ui.view.welcome_window")
 
 local is_virtual_revision = helpers.is_virtual_revision
 local prepare_buffer = helpers.prepare_buffer
+local is_panel_placeholder = helpers.is_panel_placeholder
 local show_real_file_buffer = helpers.show_real_file_buffer
 local open_real_file = helpers.open_real_file
 local compute_and_render = render.compute_and_render
@@ -40,25 +41,6 @@ local setup_all_keymaps = view_keymaps.setup_all_keymaps
 ---@param filetype? string
 ---@param on_ready? function
 ---@return table|nil
---- True when the panel opens before any file is chosen, so the panes start
---- empty and the panel fills them on first selection.
---- @param session_config SessionConfig
---- @return boolean
-local function is_panel_placeholder(session_config)
-  local panel_cfg = session_config.panel
-  if not panel_cfg then
-    return false
-  end
-  if panel_cfg.name == "history" then
-    return panel_cfg.data ~= nil
-  end
-  if panel_cfg.name == "explorer" then
-    -- Empty paths, or dir mode, which has no git_root but does have panel data.
-    return path.is_empty(session_config.original) or (not session_config.git_root and panel_cfg.data ~= nil)
-  end
-  return false
-end
-
 --- Split direction that lands the modified pane on the side the user asked for.
 --- Explicit rather than relying on 'splitright'.
 --- @return string

--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -16,6 +16,7 @@ local history_module = require("codediff.ui.history")
 local layout = require("codediff.ui.layout")
 
 local helpers = require("codediff.ui.view.helpers")
+local readiness = require("codediff.ui.view.readiness")
 local render = require("codediff.ui.view.render")
 local view_keymaps = require("codediff.ui.view.keymaps")
 local conflict_window = require("codediff.ui.view.conflict_window")
@@ -303,13 +304,23 @@ end
 --- @param modified_is_virtual boolean
 --- @param render function
 local function render_when_loaded(tabpage, original_info, modified_info, original_is_virtual, modified_is_virtual, render)
-  if not (original_is_virtual or modified_is_virtual) then
+  local awaited = {}
+  if original_is_virtual then
+    awaited[#awaited + 1] = "original"
+  end
+  if modified_is_virtual then
+    awaited[#awaited + 1] = "modified"
+  end
+  if #awaited == 0 then
     vim.schedule(render)
     return
   end
 
   local group = vim.api.nvim_create_augroup("CodeDiffVirtualFileHighlight_" .. tabpage, { clear = true })
-  local loaded = {}
+  local ready = readiness.when_all(awaited, function()
+    vim.schedule(render)
+    vim.api.nvim_del_augroup_by_id(group)
+  end)
 
   vim.api.nvim_create_autocmd("User", {
     group = group,
@@ -319,22 +330,11 @@ local function render_when_loaded(tabpage, original_info, modified_info, origina
       if not buf then
         return
       end
-      local ours = (original_is_virtual and buf == original_info.bufnr) or (modified_is_virtual and buf == modified_info.bufnr)
-      if not ours then
-        return
+      if original_is_virtual and buf == original_info.bufnr then
+        ready.done("original")
       end
-      loaded[buf] = true
-
-      local ready = true
-      if original_is_virtual and not loaded[original_info.bufnr] then
-        ready = false
-      end
-      if modified_is_virtual and not loaded[modified_info.bufnr] then
-        ready = false
-      end
-      if ready then
-        vim.schedule(render)
-        vim.api.nvim_del_augroup_by_id(group)
+      if modified_is_virtual and buf == modified_info.bufnr then
+        ready.done("modified")
       end
     end,
   })
@@ -485,11 +485,23 @@ end
 --- @param wait_state table { original: boolean, modified: boolean }
 --- @param render function
 local function render_when_reloaded(tabpage, original_info, modified_info, wait_state, render)
-  if not (wait_state.original or wait_state.modified) then
+  local awaited = {}
+  if wait_state.original then
+    awaited[#awaited + 1] = "original"
+  end
+  if wait_state.modified then
+    awaited[#awaited + 1] = "modified"
+  end
+  if #awaited == 0 then
     return
   end
 
   local group = vim.api.nvim_create_augroup("CodeDiffVirtualFileUpdate_" .. tabpage, { clear = true })
+  local ready = readiness.when_all(awaited, function()
+    vim.schedule(render)
+    vim.api.nvim_del_augroup_by_id(group)
+  end)
+
   vim.api.nvim_create_autocmd("User", {
     group = group,
     pattern = "CodeDiffVirtualFileLoaded",
@@ -498,15 +510,11 @@ local function render_when_reloaded(tabpage, original_info, modified_info, wait_
       if not buf then
         return
       end
-      if wait_state.original and buf == original_info.bufnr then
-        wait_state.original = false
+      if buf == original_info.bufnr then
+        ready.done("original")
       end
-      if wait_state.modified and buf == modified_info.bufnr then
-        wait_state.modified = false
-      end
-      if not wait_state.original and not wait_state.modified then
-        vim.schedule(render)
-        vim.api.nvim_del_augroup_by_id(group)
+      if buf == modified_info.bufnr then
+        ready.done("modified")
       end
     end,
   })

--- a/lua/codediff/ui/view/toggle.lua
+++ b/lua/codediff/ui/view/toggle.lua
@@ -36,7 +36,14 @@ local function normalize_inline_layout(tabpage)
   return true
 end
 
-local function normalize_side_by_side_layout(tabpage)
+--- Reshape a tab so the side-by-side code can work on it: one pane, and a
+--- session that says so. side_by_side.update opens the second pane itself when
+--- it sees single_pane.
+--- Exported because conflict mode needs it too: a conflicted file forces the
+--- side-by-side layout, and an inline tab is not in a shape it can use.
+--- @param tabpage number
+--- @return boolean
+function M.normalize_side_by_side_layout(tabpage)
   local session = lifecycle.get_session(tabpage)
   if not session then
     return false
@@ -101,7 +108,7 @@ function M.toggle(tabpage)
   end
 
   local target_layout = session.layout == "inline" and "side-by-side" or "inline"
-  local normalize = target_layout == "inline" and normalize_inline_layout or normalize_side_by_side_layout
+  local normalize = target_layout == "inline" and normalize_inline_layout or M.normalize_side_by_side_layout
   local previous_layout = session.layout
 
   -- Disable compact mode before changing layout (window IDs will change)

--- a/tests/ui/conflict/inline_tab_conflict_spec.lua
+++ b/tests/ui/conflict/inline_tab_conflict_spec.lua
@@ -1,0 +1,112 @@
+-- A conflicted file forces the side-by-side layout, but the tab it lands in
+-- may be shaped for inline: one pane, with both sides pointing at it.
+--
+-- Selecting a conflicted file from the explorer goes through view.update, and
+-- the side-by-side code assumed it had two panes to write into. It wrote both
+-- sides into the same window -- THEIRS overwrote OURS -- and never opened the
+-- result pane. The user saw one window of THEIRS, no conflict markers, and no
+-- keymaps to resolve anything.
+--
+-- Opening the same file with :CodeDiff was fine, because that path goes
+-- through create, which builds the tab from scratch.
+
+local h = dofile("tests/helpers.lua")
+
+describe("conflicted file in an inline tab", function()
+  local repo, saved_layout
+
+  before_each(function()
+    h.ensure_plugin_loaded()
+    local config = require("codediff.config")
+    saved_layout = config.options.diff.layout
+    config.options.diff.layout = "inline"
+
+    repo = h.create_temp_git_repo()
+    repo.write_file("conf.txt", { "base1", "base2", "base3" })
+    repo.git("add -A")
+    repo.git("commit -m base")
+    repo.git("checkout -b feature")
+    repo.write_file("conf.txt", { "FEATURE1", "base2", "base3" })
+    repo.git("commit -am feature")
+    repo.git("checkout main")
+    repo.write_file("conf.txt", { "MAIN1", "base2", "base3" })
+    repo.git("commit -am main")
+    local merge_out = repo.git("merge feature --no-edit")
+    assert.is_true(merge_out:find("CONFLICT", 1, true) ~= nil, "merge must conflict")
+  end)
+
+  after_each(function()
+    require("codediff.config").options.diff.layout = saved_layout
+    if repo then
+      repo.cleanup()
+    end
+    while vim.fn.tabpagenr("$") > 1 do
+      vim.cmd("tabclose!")
+    end
+  end)
+
+  it("opens the three-pane merge view, not a single pane", function()
+    local lifecycle = require("codediff.ui.lifecycle")
+    local path = require("codediff.core.path")
+
+    vim.cmd("edit " .. repo.path("conf.txt"))
+    vim.cmd("CodeDiff --inline")
+    assert.is_true(
+      vim.wait(15000, function()
+        return h.find_window_by_filetype("codediff-explorer") ~= nil
+      end, 50),
+      "inline explorer never opened"
+    )
+
+    local tabpage = vim.api.nvim_get_current_tabpage()
+    assert.equals("inline", lifecycle.get_session(tabpage).layout, "tab should start out inline")
+
+    -- Same config the explorer builds for a file in the Merge Changes group,
+    -- including which side lands on the left: conflict_ours_position decides,
+    -- and it defaults to putting OURS on the right.
+    local ours_position = require("codediff.config").options.diff.conflict_ours_position or "right"
+    local left_rev = ours_position == "right" and ":3" or ":2"
+    local right_rev = ours_position == "right" and ":2" or ":3"
+    local left_text = ours_position == "right" and "FEATURE1" or "MAIN1"
+    local right_text = ours_position == "right" and "MAIN1" or "FEATURE1"
+
+    require("codediff.ui.view").update(tabpage, {
+      git_root = repo.dir,
+      original = path.make_ref("conf.txt", repo.dir),
+      modified = path.make_ref("conf.txt", repo.dir),
+      original_revision = left_rev,
+      modified_revision = right_rev,
+      conflict = true,
+    }, false)
+
+    -- The result pane appears before the two sides finish loading, so wait for
+    -- content rather than for the window.
+    assert.is_true(
+      vim.wait(15000, function()
+        local s = lifecycle.get_session(tabpage)
+        if not (s and s.result_win and vim.api.nvim_win_is_valid(s.result_win)) then
+          return false
+        end
+        if not (s.original_win and s.modified_win and vim.api.nvim_win_is_valid(s.original_win) and vim.api.nvim_win_is_valid(s.modified_win)) then
+          return false
+        end
+        local o = vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(s.original_win), 0, -1, false)
+        local m = vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(s.modified_win), 0, -1, false)
+        return table.concat(o, "\n"):find(left_text, 1, true) ~= nil and table.concat(m, "\n"):find(right_text, 1, true) ~= nil
+      end, 50),
+      "conflicted file must open a result pane with both sides loaded"
+    )
+
+    local session = lifecycle.get_session(tabpage)
+
+    -- Both sides need their own window, or one overwrites the other.
+    assert.is_not_nil(session.original_win, "OURS needs a window")
+    assert.is_not_nil(session.modified_win, "THEIRS needs a window")
+    assert.not_equal(session.original_win, session.modified_win, "the two sides must not share a window")
+
+    local ours = vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(session.original_win), 0, -1, false)
+    local theirs = vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(session.modified_win), 0, -1, false)
+    h.assert_contains(table.concat(ours, "\n"), left_text, "left pane holds the wrong side")
+    h.assert_contains(table.concat(theirs, "\n"), right_text, "right pane holds the wrong side")
+  end)
+end)

--- a/tests/ui/view/readiness_spec.lua
+++ b/tests/ui/view/readiness_spec.lua
@@ -1,0 +1,77 @@
+-- Waiting for both sides of a diff to arrive.
+--
+-- This bookkeeping used to be written out at three call sites, twice under the
+-- name `pending` and once as a table keyed by buffer number. Each copy could
+-- drift, and one of them did: keying by buffer number meant that when both
+-- sides shared a buffer, one arrival was counted as two.
+
+local readiness = require("codediff.ui.view.readiness")
+
+describe("readiness.when_all", function()
+  it("waits for every side before running", function()
+    local runs = 0
+    local ready = readiness.when_all({ "original", "modified" }, function()
+      runs = runs + 1
+    end)
+
+    assert.equals(0, runs, "must not run before any side arrives")
+    assert.is_true(ready.pending())
+
+    ready.done("original")
+    assert.equals(0, runs, "must not run with one side outstanding")
+    assert.is_true(ready.pending())
+
+    ready.done("modified")
+    assert.equals(1, runs, "must run once the last side arrives")
+    assert.is_false(ready.pending())
+  end)
+
+  it("runs immediately when there is nothing to wait for", function()
+    local runs = 0
+    local ready = readiness.when_all({}, function()
+      runs = runs + 1
+    end)
+
+    assert.equals(1, runs)
+    assert.is_false(ready.pending())
+  end)
+
+  it("runs once even if a side is reported twice", function()
+    local runs = 0
+    local ready = readiness.when_all({ "original", "modified" }, function()
+      runs = runs + 1
+    end)
+
+    ready.done("original")
+    ready.done("original")
+    ready.done("modified")
+    ready.done("modified")
+
+    assert.equals(1, runs, "a repeated arrival must not render again")
+  end)
+
+  it("ignores sides it was never asked to wait for", function()
+    local runs = 0
+    local ready = readiness.when_all({ "modified" }, function()
+      runs = runs + 1
+    end)
+
+    ready.done("original")
+    assert.equals(0, runs, "an unawaited side must not satisfy the wait")
+
+    ready.done("modified")
+    assert.equals(1, runs)
+  end)
+
+  it("counts a duplicated name once", function()
+    -- Both sides of a single-file view can name the same thing. Counting it
+    -- twice would leave the wait outstanding forever.
+    local runs = 0
+    local ready = readiness.when_all({ "original", "original" }, function()
+      runs = runs + 1
+    end)
+
+    ready.done("original")
+    assert.equals(1, runs)
+  end)
+end)


### PR DESCRIPTION
## Summary

Finishes what #527 started: `inline_view.lua`'s two large functions are split the same way, the two layouts are compared step by step, and the one thing that turned out to be genuinely shared is now shared. That comparison also found a bug, fixed here.

```
M.create   245 -> 124 lines
M.update   163 ->  85 lines
```

## What the comparison found

Not much duplication. Four steps ended up with the same name in both files and **none of them had the same body**:

| | side-by-side | inline |
|---|---|---|
| `apply_pane_options` | two panes, plus `list` | one pane |
| `make_reapply_keymaps` | handles conflicts | does not |
| `finish_create` | no layout pass | arranges the layout |
| `render_when_loaded` | waits on `BufReadCmd` | fetches from git itself |

The last difference is real and load-bearing: inline never gives the original side a window, and a `codediff://` buffer carries `bufhidden=wipe`, so it would be destroyed the moment nothing displayed it.

So the premise in #527's description — "the same flow written twice" — was wrong. They change together because they implement the same feature surface, not because they share code. (That description also said 22 of 34 commits touched both files; excluding merge commits it is 17 of 31.)

## What was genuinely shared

**`is_panel_placeholder`** — character-identical in both files, moved to `helpers.lua`.

**Waiting for both sides.** A diff needs both sides before it renders, each arrives on its own schedule, and whichever callback runs last has to start the render. That bookkeeping was written out at three call sites — twice as flags named `pending` and `wait_state`, once as a table keyed by buffer number:

```lua
local ready = readiness.when_all({ "original", "modified" }, render)
ready.done("original")
```

The three sites keep what actually differs: how they learn a side has landed.

Keying by buffer number was a latent bug — when both sides share a buffer, one arrival counted as two. Names cannot collide that way.

## The bug

Selecting a conflicted file from the explorer while the tab is in the inline layout gave **a single pane holding only THEIRS**: no OURS, no result pane, and none of the keymaps that resolve a conflict. The explorer listed the file under Merge Changes and then could not show it.

A conflicted file forces the side-by-side layout, but that only chose which code ran — it did not reshape the tab. An inline tab has one pane with both sides pointing at it, so `side_by_side.update` wrote both into the same window and the second overwrote the first.

`view.update` now normalises the tab first, reusing the same path a layout toggle takes. Opening the same file with `:CodeDiff` was always fine; that goes through `create`, which builds the tab from scratch.

Not reported by anyone. Found by lining the two layouts' steps up against each other.

## Testing

89 specs green. Behaviour compared before and after across seven scenarios — two real files, `:CodeDiff file HEAD`, an explorer placeholder, an explorer file selection, and three inline paths — recording window count, panel, merge flag, window options, diff size, buffer contents and screen columns. **Byte-identical.**

Mutations: not preparing the hidden original fails 10 specs; treating the modified side as always virtual fails 3; not filling the original from a real file fails 1. Removing the normalise call fails the new conflict spec. Five specs cover `when_all`; four mutations against it fail one or two each.

## Two notes

`readiness.when_all` was first written with an "already ran" flag. No test could be made to fail without it — reporting a name removes it, so the count can only reach zero once — so it was removed rather than left as protection against a hazard that does not exist.

A spec for the both-sides-virtual inline path was written and dropped: it was flaky under the parallel runner and did not catch the mutation it was meant to catch. That path is a pure move, verified line by line, but it is untested.
