### PR TITLE
refactor(session): build a session from the config it opened

### DIFF
--- a/lua/codediff/ui/lifecycle/session.lua
+++ b/lua/codediff/ui/lifecycle/session.lua
@@ -57,28 +57,24 @@ end
 -- Expose compute_virtual_uri for other modules
 M.compute_virtual_uri = compute_virtual_uri
 
---- @class CreateSessionOpts
---- @field panel table? Panel descriptor { name, data }; nil for a bare diff
---- @field merge boolean? 3-way merge view. The single answer to "is this a
----   merge view"; result_bufnr says only whether the result pane is built yet.
---- @field git_root string?
---- @field original Path|string
---- @field modified Path|string
---- @field original_revision string?
---- @field modified_revision string?
+--- What a layout produces once it has opened its panes and computed a diff.
+--- Everything else a session needs is copied from the SessionConfig it was
+--- asked to open, so a change to that shape lands in one place rather than at
+--- every call site.
+--- @class SessionPanes
 --- @field original_bufnr number
 --- @field modified_bufnr number
 --- @field original_win number
 --- @field modified_win number
 --- @field lines_diff table? Initial diff result
 --- @field reapply_keymaps function? Called when the session's shape changes
---- @field exit_on_close boolean? Exit Neovim when this session closes
 
 --- @param tabpage number
---- @param opts CreateSessionOpts
-function M.create_session(tabpage, opts)
+--- @param session_config SessionConfig What was asked for
+--- @param panes SessionPanes What the layout built for it
+function M.create_session(tabpage, session_config, panes)
   local state = require("codediff.ui.lifecycle.state")
-  local original_bufnr, modified_bufnr = opts.original_bufnr, opts.modified_bufnr
+  local original_bufnr, modified_bufnr = panes.original_bufnr, panes.modified_bufnr
   -- Save buffer states
   local original_state = state.save_buffer_state(original_bufnr)
   local modified_state = state.save_buffer_state(modified_bufnr)
@@ -89,28 +85,28 @@ function M.create_session(tabpage, opts)
     -- `panel.data` is construction material: panel.lua consumes it to build the
     -- panel, which copies forward whatever it still needs (pathspec,
     -- status_result). Keeping it on the session would be a second, stale copy.
-    panel = opts.panel and { name = opts.panel.name } or nil,
-    merge = opts.merge or nil,
-    git_root = opts.git_root,
-    original = opts.original,
-    modified = opts.modified,
-    original_revision = opts.original_revision,
-    modified_revision = opts.modified_revision,
+    panel = session_config.panel and { name = session_config.panel.name } or nil,
+    merge = session_config.conflict or nil,
+    git_root = session_config.git_root,
+    original = session_config.original,
+    modified = session_config.modified,
+    original_revision = session_config.original_revision,
+    modified_revision = session_config.modified_revision,
 
     -- Buffers & Windows
     original_bufnr = original_bufnr,
     modified_bufnr = modified_bufnr,
-    original_win = opts.original_win,
-    modified_win = opts.modified_win,
+    original_win = panes.original_win,
+    modified_win = panes.modified_win,
     original_state = original_state,
     modified_state = modified_state,
 
     -- Lifecycle state
     layout = "side-by-side",
-    exit_on_close = opts.exit_on_close == true,
+    exit_on_close = session_config.exit_on_close == true,
     suspended = false,
     single_side = nil,
-    stored_diff_result = opts.lines_diff,
+    stored_diff_result = panes.lines_diff,
     changedtick = {
       original = vim.api.nvim_buf_get_changedtick(original_bufnr),
       modified = vim.api.nvim_buf_get_changedtick(modified_bufnr),
@@ -124,7 +120,7 @@ function M.create_session(tabpage, opts)
     result_bufnr = nil,
     result_win = nil,
     conflict_files = {}, -- Tracks files opened in conflict mode for unsaved warning
-    reapply_keymaps = opts.reapply_keymaps,
+    reapply_keymaps = panes.reapply_keymaps,
     -- Owns every mapping this session installs, so teardown can hand each key
     -- back to whatever owned it before codediff.
     keymaps = keymap.new("codediff-session:" .. tostring(tabpage)),
@@ -133,8 +129,8 @@ function M.create_session(tabpage, opts)
   welcome_window.capture_session_profiles(active_diffs[tabpage])
 
   -- Mark windows with restore flag
-  vim.w[opts.original_win].codediff_restore = 1
-  vim.w[opts.modified_win].codediff_restore = 1
+  vim.w[panes.original_win].codediff_restore = 1
+  vim.w[panes.modified_win].codediff_restore = 1
 
   -- Continuously enforce inlay hint settings via LspAttach (handles LazyVim re-enabling)
   if config.options.diff.disable_inlay_hints and vim.lsp.inlay_hint then

--- a/lua/codediff/ui/view/inline_view.lua
+++ b/lua/codediff/ui/view/inline_view.lua
@@ -306,20 +306,12 @@ function M.create(session_config, filetype, on_ready)
     apply_pane_options(modified_win)
 
     -- The panel populates this session on first file selection.
-    lifecycle.create_session(tabpage, {
-      panel = session_config.panel,
-      merge = session_config.conflict,
-      git_root = session_config.git_root,
-      original = "",
-      modified = "",
-      original_revision = nil,
-      modified_revision = nil,
+    lifecycle.create_session(tabpage, session_config, {
       original_bufnr = orig_scratch,
       modified_bufnr = mod_scratch,
       original_win = modified_win,
       modified_win = modified_win, -- both point to the single window
       lines_diff = {},
-      exit_on_close = session_config.exit_on_close,
       reapply_keymaps = make_reapply_keymaps(tabpage, orig_scratch),
     })
 
@@ -361,20 +353,12 @@ function M.create(session_config, filetype, on_ready)
       return
     end
 
-    lifecycle.create_session(tabpage, {
-      panel = session_config.panel,
-      merge = session_config.conflict,
-      git_root = session_config.git_root,
-      original = session_config.original,
-      modified = session_config.modified,
-      original_revision = session_config.original_revision,
-      modified_revision = session_config.modified_revision,
+    lifecycle.create_session(tabpage, session_config, {
       original_bufnr = original_info.bufnr,
       modified_bufnr = modified_info.bufnr,
       original_win = modified_win,
       modified_win = modified_win,
       lines_diff = lines_diff,
-      exit_on_close = session_config.exit_on_close,
       reapply_keymaps = make_reapply_keymaps(tabpage, original_info.bufnr),
     })
 

--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -213,20 +213,12 @@ local function render_conflict_view(ctx)
         return
       end
 
-      lifecycle.create_session(tabpage, {
-        panel = session_config.panel,
-        merge = session_config.conflict,
-        git_root = session_config.git_root,
-        original = session_config.original,
-        modified = session_config.modified,
-        original_revision = session_config.original_revision,
-        modified_revision = session_config.modified_revision,
+      lifecycle.create_session(tabpage, session_config, {
         original_bufnr = original_info.bufnr,
         modified_bufnr = modified_info.bufnr,
         original_win = original_win,
         modified_win = modified_win,
         lines_diff = conflict_diffs.base_to_modified_diff,
-        exit_on_close = session_config.exit_on_close,
         reapply_keymaps = make_reapply_keymaps(tabpage, { conflict = true }),
       })
 
@@ -266,20 +258,12 @@ local function render_diff_view(ctx)
     return
   end
 
-  lifecycle.create_session(tabpage, {
-    panel = session_config.panel,
-    merge = session_config.conflict,
-    git_root = session_config.git_root,
-    original = session_config.original,
-    modified = session_config.modified,
-    original_revision = session_config.original_revision,
-    modified_revision = session_config.modified_revision,
+  lifecycle.create_session(tabpage, session_config, {
     original_bufnr = original_info.bufnr,
     modified_bufnr = modified_info.bufnr,
     original_win = ctx.original_win,
     modified_win = ctx.modified_win,
     lines_diff = lines_diff,
-    exit_on_close = session_config.exit_on_close,
     reapply_keymaps = make_reapply_keymaps(tabpage),
   })
 
@@ -363,20 +347,12 @@ function M.create(session_config, filetype, on_ready)
 
   if placeholder then
     -- The panel populates this session on first file selection.
-    lifecycle.create_session(tabpage, {
-      panel = session_config.panel,
-      merge = session_config.conflict,
-      git_root = session_config.git_root,
-      original = "", -- Empty paths indicate placeholder
-      modified = "",
-      original_revision = nil,
-      modified_revision = nil,
+    lifecycle.create_session(tabpage, session_config, {
       original_bufnr = original_info.bufnr,
       modified_bufnr = modified_info.bufnr,
       original_win = original_win,
       modified_win = modified_win,
       lines_diff = {}, -- Empty diff result - will be updated on first file selection
-      exit_on_close = session_config.exit_on_close,
       reapply_keymaps = make_reapply_keymaps(tabpage),
     })
   else

--- a/tests/ui/gutter_signs_spec.lua
+++ b/tests/ui/gutter_signs_spec.lua
@@ -259,6 +259,7 @@ describe("Gutter signs", function()
     lifecycle.create_session(tabpage, {
       original = path.empty(),
       modified = path.make_ref("modified.txt", nil),
+    }, {
       original_bufnr = session.original_bufnr,
       modified_bufnr = session.modified_bufnr,
       original_win = session.original_win,
@@ -284,6 +285,7 @@ describe("Gutter signs", function()
     lifecycle.create_session(tabpage, {
       original = path.make_ref("original.txt", nil),
       modified = path.make_ref("modified.txt", nil),
+    }, {
       original_bufnr = session.original_bufnr,
       modified_bufnr = session.modified_bufnr,
       original_win = session.original_win,

--- a/tests/ui/layout_spec.lua
+++ b/tests/ui/layout_spec.lua
@@ -1213,6 +1213,7 @@ describe("Layout Manager", function()
       git_root = "/tmp",
       original = "",
       modified = "",
+    }, {
       original_bufnr = orig_buf,
       modified_bufnr = mod_buf,
       original_win = orig_win,

--- a/tests/ui/lifecycle/close_spec.lua
+++ b/tests/ui/lifecycle/close_spec.lua
@@ -24,12 +24,13 @@ local function create_session(exit_on_close)
   lifecycle.create_session(tabpage, {
     original = "original.txt",
     modified = "modified.txt",
+    exit_on_close = exit_on_close,
+  }, {
     original_bufnr = original_bufnr,
     modified_bufnr = modified_bufnr,
     original_win = windows[1],
     modified_win = windows[2],
     lines_diff = {},
-    exit_on_close = exit_on_close,
   })
   return tabpage
 end

--- a/tests/ui/lifecycle/lifecycle_spec.lua
+++ b/tests/ui/lifecycle/lifecycle_spec.lua
@@ -19,14 +19,14 @@ describe("Render Lifecycle", function()
   it("Creates and completes a new diff session successfully", function()
     local left_buf = vim.api.nvim_create_buf(false, true)
     local right_buf = vim.api.nvim_create_buf(false, true)
-    
+
     vim.cmd('tabnew')
     local tabpage = vim.api.nvim_get_current_tabpage()
     vim.cmd('vsplit')
     local left_win = vim.api.nvim_get_current_win()
     vim.cmd('wincmd l')
     local right_win = vim.api.nvim_get_current_win()
-    
+
     vim.api.nvim_win_set_buf(left_win, left_buf)
     vim.api.nvim_win_set_buf(right_win, right_buf)
 
@@ -41,6 +41,7 @@ describe("Render Lifecycle", function()
         modified = "test_file2.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+      }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
@@ -61,14 +62,14 @@ describe("Render Lifecycle", function()
   it("Cleanup removes all highlights from buffers", function()
     local left_buf = vim.api.nvim_create_buf(false, true)
     local right_buf = vim.api.nvim_create_buf(false, true)
-    
+
     vim.cmd('tabnew')
     local tabpage = vim.api.nvim_get_current_tabpage()
     vim.cmd('vsplit')
     local left_win = vim.api.nvim_get_current_win()
     vim.cmd('wincmd l')
     local right_win = vim.api.nvim_get_current_win()
-    
+
     vim.api.nvim_win_set_buf(left_win, left_buf)
     vim.api.nvim_win_set_buf(right_win, right_buf)
 
@@ -76,19 +77,20 @@ describe("Render Lifecycle", function()
     local modified = {"line 1", "added"}
     vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, original)
     vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, modified)
-    
+
     local lines_diff = diff.compute_diff(original, modified)
     lifecycle.create_session(tabpage, {
         original = "test_file1.txt",
         modified = "test_file2.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+    }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
         modified_win = right_win,
         lines_diff = lines_diff,
-      })
+    })
 
     -- Manually add some highlights to verify cleanup
     vim.api.nvim_buf_set_extmark(right_buf, highlights.ns_highlight, 1, 0, {
@@ -113,14 +115,14 @@ describe("Render Lifecycle", function()
   it("Cleanup removes all filler extmarks from buffers", function()
     local left_buf = vim.api.nvim_create_buf(false, true)
     local right_buf = vim.api.nvim_create_buf(false, true)
-    
+
     vim.cmd('tabnew')
     local tabpage = vim.api.nvim_get_current_tabpage()
     vim.cmd('vsplit')
     local left_win = vim.api.nvim_get_current_win()
     vim.cmd('wincmd l')
     local right_win = vim.api.nvim_get_current_win()
-    
+
     vim.api.nvim_win_set_buf(left_win, left_buf)
     vim.api.nvim_win_set_buf(right_win, right_buf)
 
@@ -128,19 +130,20 @@ describe("Render Lifecycle", function()
     local modified = {"line 1", "line 2", "line 3"}
     vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, original)
     vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, modified)
-    
+
     local lines_diff = diff.compute_diff(original, modified)
     lifecycle.create_session(tabpage, {
         original = "test_file1.txt",
         modified = "test_file2.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+    }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
         modified_win = right_win,
         lines_diff = lines_diff,
-      })
+    })
 
     -- Manually add filler
     vim.api.nvim_buf_set_extmark(left_buf, highlights.ns_filler, 0, 0, {
@@ -170,28 +173,29 @@ describe("Render Lifecycle", function()
       local left_buf = vim.api.nvim_create_buf(false, true)
       local right_buf = vim.api.nvim_create_buf(false, true)
       table.insert(bufs, {left_buf, right_buf})
-      
+
       vim.cmd('tabnew')
       local tabpage = vim.api.nvim_get_current_tabpage()
       table.insert(tabs, tabpage)
-      
+
       vim.cmd('vsplit')
       local left_win = vim.api.nvim_get_current_win()
       vim.cmd('wincmd l')
       local right_win = vim.api.nvim_get_current_win()
-      
+
       vim.api.nvim_win_set_buf(left_win, left_buf)
       vim.api.nvim_win_set_buf(right_win, right_buf)
 
       local original = {"line 1"}
       local modified = {"line 1", "added"}
       local lines_diff = diff.compute_diff(original, modified)
-      
+
       lifecycle.create_session(tabpage, {
         original = "test_file1.txt",
         modified = "test_file2.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+      }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
@@ -235,14 +239,14 @@ describe("Render Lifecycle", function()
   it("Handles multiple register calls for the same tabpage", function()
     local left_buf = vim.api.nvim_create_buf(false, true)
     local right_buf = vim.api.nvim_create_buf(false, true)
-    
+
     vim.cmd('tabnew')
     local tabpage = vim.api.nvim_get_current_tabpage()
     vim.cmd('vsplit')
     local left_win = vim.api.nvim_get_current_win()
     vim.cmd('wincmd l')
     local right_win = vim.api.nvim_get_current_win()
-    
+
     vim.api.nvim_win_set_buf(left_win, left_buf)
     vim.api.nvim_win_set_buf(right_win, right_buf)
 
@@ -256,12 +260,13 @@ describe("Render Lifecycle", function()
         modified = "test_file2.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+    }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
         modified_win = right_win,
         lines_diff = lines_diff,
-      })
+    })
 
     -- Register again with updated data
     local original2 = {"line 3"}
@@ -274,6 +279,7 @@ describe("Render Lifecycle", function()
         modified = "test_file4.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+      }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
@@ -318,12 +324,13 @@ describe("Render Lifecycle", function()
         modified = "b.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+    }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = lw,
         modified_win = rw,
         lines_diff = ld,
-      })
+    })
     assert.is_not_nil(lifecycle.get_session(real_tab))
 
     local fake_tabpage = 99999
@@ -346,32 +353,33 @@ describe("Render Lifecycle", function()
   it("Handles cleanup when buffers are already deleted", function()
     local left_buf = vim.api.nvim_create_buf(false, true)
     local right_buf = vim.api.nvim_create_buf(false, true)
-    
+
     vim.cmd('tabnew')
     local tabpage = vim.api.nvim_get_current_tabpage()
     vim.cmd('vsplit')
     local left_win = vim.api.nvim_get_current_win()
     vim.cmd('wincmd l')
     local right_win = vim.api.nvim_get_current_win()
-    
+
     vim.api.nvim_win_set_buf(left_win, left_buf)
     vim.api.nvim_win_set_buf(right_win, right_buf)
 
     local original = {"line 1"}
     local modified = {"line 2"}
     local lines_diff = diff.compute_diff(original, modified)
-    
+
     lifecycle.create_session(tabpage, {
         original = "test_file1.txt",
         modified = "test_file2.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+    }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
         modified_win = right_win,
         lines_diff = lines_diff,
-      })
+    })
 
     -- Delete buffers before cleanup
     vim.api.nvim_buf_delete(left_buf, {force = true})
@@ -396,14 +404,14 @@ describe("Render Lifecycle", function()
   it("Registered session tracks correct buffer numbers", function()
     local left_buf = vim.api.nvim_create_buf(false, true)
     local right_buf = vim.api.nvim_create_buf(false, true)
-    
+
     vim.cmd('tabnew')
     local tabpage = vim.api.nvim_get_current_tabpage()
     vim.cmd('vsplit')
     local left_win = vim.api.nvim_get_current_win()
     vim.cmd('wincmd l')
     local right_win = vim.api.nvim_get_current_win()
-    
+
     vim.api.nvim_win_set_buf(left_win, left_buf)
     vim.api.nvim_win_set_buf(right_win, right_buf)
 
@@ -416,12 +424,13 @@ describe("Render Lifecycle", function()
         modified = "test_file2.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+    }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
         modified_win = right_win,
         lines_diff = lines_diff,
-      })
+    })
 
     -- Verify buffers are valid and accessible
     assert.is_true(vim.api.nvim_buf_is_valid(left_buf), "Left buffer should be valid")
@@ -436,14 +445,14 @@ describe("Render Lifecycle", function()
   it("Registered session tracks correct window numbers", function()
     local left_buf = vim.api.nvim_create_buf(false, true)
     local right_buf = vim.api.nvim_create_buf(false, true)
-    
+
     vim.cmd('tabnew')
     local tabpage = vim.api.nvim_get_current_tabpage()
     vim.cmd('vsplit')
     local left_win = vim.api.nvim_get_current_win()
     vim.cmd('wincmd l')
     local right_win = vim.api.nvim_get_current_win()
-    
+
     vim.api.nvim_win_set_buf(left_win, left_buf)
     vim.api.nvim_win_set_buf(right_win, right_buf)
 
@@ -456,12 +465,13 @@ describe("Render Lifecycle", function()
         modified = "test_file2.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+    }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
         modified_win = right_win,
         lines_diff = lines_diff,
-      })
+    })
 
     -- Verify windows are valid
     assert.is_true(vim.api.nvim_win_is_valid(left_win), "Left window should be valid")
@@ -477,7 +487,7 @@ describe("Render Lifecycle", function()
     -- Create two sessions
     local bufs1 = {vim.api.nvim_create_buf(false, true), vim.api.nvim_create_buf(false, true)}
     local bufs2 = {vim.api.nvim_create_buf(false, true), vim.api.nvim_create_buf(false, true)}
-    
+
     vim.cmd('tabnew')
     local tab1 = vim.api.nvim_get_current_tabpage()
     vim.cmd('vsplit')
@@ -508,6 +518,7 @@ describe("Render Lifecycle", function()
       modified = "test_file2.txt",
       original_revision = "WORKING",
       modified_revision = "WORKING",
+    }, {
       original_bufnr = bufs1[1],
       modified_bufnr = bufs1[2],
       original_win = left_win1,
@@ -519,6 +530,7 @@ describe("Render Lifecycle", function()
       modified = "test_file2.txt",
       original_revision = "WORKING",
       modified_revision = "WORKING",
+    }, {
       original_bufnr = bufs2[1],
       modified_bufnr = bufs2[2],
       original_win = left_win2,
@@ -552,14 +564,14 @@ describe("Render Lifecycle", function()
   it("Handles registration with empty line arrays", function()
     local left_buf = vim.api.nvim_create_buf(false, true)
     local right_buf = vim.api.nvim_create_buf(false, true)
-    
+
     vim.cmd('tabnew')
     local tabpage = vim.api.nvim_get_current_tabpage()
     vim.cmd('vsplit')
     local left_win = vim.api.nvim_get_current_win()
     vim.cmd('wincmd l')
     local right_win = vim.api.nvim_get_current_win()
-    
+
     vim.api.nvim_win_set_buf(left_win, left_buf)
     vim.api.nvim_win_set_buf(right_win, right_buf)
 
@@ -573,6 +585,7 @@ describe("Render Lifecycle", function()
         modified = "test_file2.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+      }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
@@ -609,35 +622,36 @@ describe("Render Lifecycle", function()
   it("Cleanup removes only extmarks, preserves buffer content", function()
     local left_buf = vim.api.nvim_create_buf(false, true)
     local right_buf = vim.api.nvim_create_buf(false, true)
-    
+
     vim.cmd('tabnew')
     local tabpage = vim.api.nvim_get_current_tabpage()
     vim.cmd('vsplit')
     local left_win = vim.api.nvim_get_current_win()
     vim.cmd('wincmd l')
     local right_win = vim.api.nvim_get_current_win()
-    
+
     vim.api.nvim_win_set_buf(left_win, left_buf)
     vim.api.nvim_win_set_buf(right_win, right_buf)
 
     local original = {"line 1", "line 2", "line 3"}
     local modified = {"line 1", "modified", "line 3"}
-    
+
     vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, original)
     vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, modified)
-    
+
     local lines_diff = diff.compute_diff(original, modified)
     lifecycle.create_session(tabpage, {
         original = "test_file1.txt",
         modified = "test_file2.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+    }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
         modified_win = right_win,
         lines_diff = lines_diff,
-      })
+    })
 
     lifecycle.cleanup(tabpage)
 
@@ -657,32 +671,33 @@ describe("Render Lifecycle", function()
   it("Handles cleanup when windows are already closed", function()
     local left_buf = vim.api.nvim_create_buf(false, true)
     local right_buf = vim.api.nvim_create_buf(false, true)
-    
+
     vim.cmd('tabnew')
     local tabpage = vim.api.nvim_get_current_tabpage()
     vim.cmd('vsplit')
     local left_win = vim.api.nvim_get_current_win()
     vim.cmd('wincmd l')
     local right_win = vim.api.nvim_get_current_win()
-    
+
     vim.api.nvim_win_set_buf(left_win, left_buf)
     vim.api.nvim_win_set_buf(right_win, right_buf)
 
     local original = {"line 1"}
     local modified = {"line 2"}
     local lines_diff = diff.compute_diff(original, modified)
-    
+
     lifecycle.create_session(tabpage, {
         original = "test_file1.txt",
         modified = "test_file2.txt",
         original_revision = "WORKING",
         modified_revision = "WORKING",
+    }, {
         original_bufnr = left_buf,
         modified_bufnr = right_buf,
         original_win = left_win,
         modified_win = right_win,
         lines_diff = lines_diff,
-      })
+    })
 
     -- Close one window
     vim.api.nvim_win_close(left_win, true)

--- a/tests/ui/lifecycle/placeholder_paths_spec.lua
+++ b/tests/ui/lifecycle/placeholder_paths_spec.lua
@@ -1,0 +1,77 @@
+-- A placeholder session stores the two paths as the empty string, while every
+-- other session stores them as Path tables. Everything that reads them reaches
+-- for .absolute or .relative, and Lua lets you index a string, so those reads
+-- quietly returned nil instead of failing. Nothing checked the nil, so it
+-- worked by coincidence rather than by design.
+--
+-- Both sides are the empty Path now. This pins that: a placeholder session must
+-- carry the same shape as any other, so a reader cannot tell them apart.
+
+local h = dofile("tests/helpers.lua")
+
+describe("placeholder session paths", function()
+  local repo, captured, restore
+
+  before_each(function()
+    h.ensure_plugin_loaded()
+
+    -- Catch the session as it is built; the explorer selects a file straight
+    -- away and replaces the placeholder, so it cannot be read afterwards.
+    local lifecycle = require("codediff.ui.lifecycle")
+    local original = lifecycle.create_session
+    captured = {}
+    lifecycle.create_session = function(tabpage, session_config, panes)
+      captured[#captured + 1] = { original = session_config.original, modified = session_config.modified }
+      return original(tabpage, session_config, panes)
+    end
+    restore = function()
+      lifecycle.create_session = original
+    end
+
+    repo = h.create_temp_git_repo()
+    repo.write_file("a.txt", { "a1" })
+    repo.git("add -A")
+    repo.git("commit -qm init")
+    repo.write_file("a.txt", { "A1 CHANGED" })
+  end)
+
+  after_each(function()
+    if restore then
+      restore()
+    end
+    if repo then
+      repo.cleanup()
+    end
+    while vim.fn.tabpagenr("$") > 1 do
+      vim.cmd("tabclose!")
+    end
+  end)
+
+  local function assert_is_path(value, label)
+    assert.equals("table", type(value), label .. " must be a Path, not a " .. type(value))
+    assert.equals("string", type(value.absolute), label .. ".absolute must be a string")
+    assert.equals("string", type(value.relative), label .. ".relative must be a string")
+  end
+
+  it("carries empty Paths, not empty strings", function()
+    vim.cmd("cd " .. vim.fn.fnameescape(repo.dir))
+    vim.cmd("CodeDiff")
+    assert.is_true(
+      vim.wait(15000, function()
+        return h.find_window_by_filetype("codediff-explorer") ~= nil
+      end, 50),
+      "explorer never opened"
+    )
+    vim.wait(1000)
+
+    assert.is_true(#captured > 0, "no session was created")
+
+    local placeholder = captured[1]
+    assert_is_path(placeholder.original, "placeholder original")
+    assert_is_path(placeholder.modified, "placeholder modified")
+
+    local path = require("codediff.core.path")
+    assert.is_true(path.is_empty(placeholder.original), "placeholder original should be an empty Path")
+    assert.is_true(path.is_empty(placeholder.modified), "placeholder modified should be an empty Path")
+  end)
+end)

--- a/tests/ui/welcome_spec.lua
+++ b/tests/ui/welcome_spec.lua
@@ -125,6 +125,7 @@ describe("Welcome Page", function()
       lifecycle.create_session(tabpage, {
         original = "",
         modified = "",
+      }, {
         original_bufnr = regular_buf,
         modified_bufnr = other_buf,
         original_win = main_win,


### PR DESCRIPTION
## Summary

Every `create_session` call passed the same fourteen fields, and eight of them were copied straight out of the `SessionConfig` the view was asked to open.

```lua
-- before, at five call sites
lifecycle.create_session(tabpage, {
  panel = session_config.panel,
  merge = session_config.conflict,
  git_root = session_config.git_root,
  original = session_config.original,
  modified = session_config.modified,
  original_revision = session_config.original_revision,
  modified_revision = session_config.modified_revision,
  exit_on_close = session_config.exit_on_close,
  original_bufnr = ..., modified_bufnr = ...,
  original_win = ..., modified_win = ...,
  lines_diff = ..., reapply_keymaps = ...,
})

-- after
lifecycle.create_session(tabpage, session_config, {
  original_bufnr = ..., modified_bufnr = ...,
  original_win = ..., modified_win = ...,
  lines_diff = ..., reapply_keymaps = ...,
})
```

The five sites are side-by-side (ordinary, placeholder, conflict) and inline (ordinary, placeholder). They exist because each new case was written by copying the nearest existing one — reasonable at the time, since nobody knew yet which parts would diverge.

**Adding a field to a session is now one line in one file. It was five**, and missing one would not fail: it would leave the field unset in one layout until something reached for it. Renaming `mode` to `panel`, adding the `merge` flag, and turning the arguments into a table each meant writing the same edit five times this month.

## Placeholder paths had to be fixed first

Placeholder sessions stored the two paths as the empty string, while every other session stored `Path` tables:

```lua
original = "",                    -- placeholder
original = session_config.original,  -- everything else
```

Every reader reaches for `.absolute` or `.relative`. Lua lets you index a string, so those reads answered `nil` rather than failing, and nothing checked the `nil`. It worked by accident.

Both are `path.empty()` now, so a reader cannot tell a placeholder apart from any other session. A new spec pins this and fails against the old strings.

## Test call sites

Twenty specs construct sessions directly — they test lifecycle itself, so that is legitimate — and were updated with the signature. That is the real cost of the change, and it is paid once.

## Testing

90 specs green. Behaviour compared before and after across seven scenarios — two real files, `:CodeDiff file HEAD`, an explorer placeholder, an explorer file selection, and three inline paths — recording window count, panel, merge flag, window options, diff size, buffer contents and screen columns. **Byte-identical.**

Verified the change does what it claims: adding `line_range = session_config.line_range` as a single line in `session.lua` reaches all five layout branches at once.

## Note on method

The twenty test call sites were rewritten by script. The first version matched on indentation and swallowed a neighbouring `nvim_create_autocmd({...})` call; it was caught by reading the diff, not by running it. The second version counts brackets to find each call's real boundary.
