### PR TITLE
refactor(explorer): decompose the file-select handler

### DIFF
--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -5,6 +5,7 @@ local Tree = require("codediff.ui.lib.tree")
 local Split = require("codediff.ui.lib.split")
 local config = require("codediff.config")
 local path = require("codediff.core.path")
+local lifecycle = require("codediff.ui.lifecycle")
 local nodes_module = require("codediff.ui.explorer.nodes")
 local tree_module = require("codediff.ui.explorer.tree")
 local keymaps_module = require("codediff.ui.explorer.keymaps")
@@ -50,6 +51,23 @@ local function show_welcome_page(explorer)
   local welcome_buf = welcome.create_buffer(width, height)
   require("codediff.ui.view.side_by_side").show_welcome(explorer.tabpage, welcome_buf)
   return true
+end
+
+--- Run `show` on the next tick, unless the user has moved on to another file
+--- by then. Every one-sided view goes through here: the explorer fires a
+--- selection for each cursor movement, so a slow open must not paint over a
+--- newer one.
+--- @param explorer table
+--- @param file_path string The file this selection was for
+--- @param show fun(is_inline: boolean)
+local function show_when_still_selected(explorer, file_path, show)
+  vim.schedule(function()
+    if explorer.current_file_path ~= file_path then
+      return
+    end
+    local session = lifecycle.get_session(explorer.tabpage)
+    show(session ~= nil and session.layout == "inline")
+  end)
 end
 
 function M.create(status_result, git_root, tabpage, width, base_revision, target_revision, opts)
@@ -254,15 +272,9 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
 
     -- Handle untracked files: show file without diff
     if file_data.status == "??" then
-      vim.schedule(function()
-        if explorer.current_file_path ~= file_data.path then
-          return
-        end
-        local sess = lifecycle.get_session(tabpage)
-        if sess and sess.layout == "inline" then
-          require("codediff.ui.view.inline_view").show_single_file(tabpage, abs_path, {
-            side = "modified",
-          })
+      show_when_still_selected(explorer, file_data.path, function(is_inline)
+        if is_inline then
+          require("codediff.ui.view.inline_view").show_single_file(tabpage, abs_path, { side = "modified" })
         else
           require("codediff.ui.view.side_by_side").show_untracked_file(tabpage, abs_path)
         end
@@ -272,43 +284,34 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
 
     -- Handle added files: only one side has the file
     if file_data.status == "A" then
-      vim.schedule(function()
-        if explorer.current_file_path ~= file_data.path then
-          return
-        end
-        local sess = lifecycle.get_session(tabpage)
-        local is_inline = sess and sess.layout == "inline"
+      -- An added file has no other side to compare against, so it is shown
+      -- one-sided. Which revision holds it depends on where it was added.
+      local revision
+      if base_revision and target_revision and target_revision ~= "WORKING" then
+        revision = target_revision
+      elseif group == "staged" then
+        revision = ":0"
+      end
 
-        if base_revision and target_revision and target_revision ~= "WORKING" then
+      show_when_still_selected(explorer, file_data.path, function(is_inline)
+        if not revision then
+          -- Added in the working tree: read it off disk.
           if is_inline then
-            require("codediff.ui.view.inline_view").show_single_file(tabpage, file_path, {
-              revision = target_revision,
-              git_root = git_root,
-              rel_path = file_path,
-              side = "modified",
-            })
-          else
-            require("codediff.ui.view.side_by_side").show_added_virtual_file(tabpage, git_root, file_path, target_revision)
-          end
-        elseif group == "staged" then
-          if is_inline then
-            require("codediff.ui.view.inline_view").show_single_file(tabpage, file_path, {
-              revision = ":0",
-              git_root = git_root,
-              rel_path = file_path,
-              side = "modified",
-            })
-          else
-            require("codediff.ui.view.side_by_side").show_added_virtual_file(tabpage, git_root, file_path, ":0")
-          end
-        else
-          if is_inline then
-            require("codediff.ui.view.inline_view").show_single_file(tabpage, abs_path, {
-              side = "modified",
-            })
+            require("codediff.ui.view.inline_view").show_single_file(tabpage, abs_path, { side = "modified" })
           else
             require("codediff.ui.view.side_by_side").show_untracked_file(tabpage, abs_path)
           end
+          return
+        end
+        if is_inline then
+          require("codediff.ui.view.inline_view").show_single_file(tabpage, file_path, {
+            revision = revision,
+            git_root = git_root,
+            rel_path = file_path,
+            side = "modified",
+          })
+        else
+          require("codediff.ui.view.side_by_side").show_added_virtual_file(tabpage, git_root, file_path, revision)
         end
       end)
       return
@@ -316,42 +319,25 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
 
     -- Handle deleted files: show old content without diff
     if file_data.status == "D" then
-      vim.schedule(function()
-        if explorer.current_file_path ~= file_data.path then
-          return
-        end
-        local sess = lifecycle.get_session(tabpage)
-        local is_inline = sess and sess.layout == "inline"
+      -- A deleted file is shown one-sided, from wherever its content still
+      -- exists. When the explorer is anchored to a base_revision -- either
+      -- `:CodeDiff HEAD~5` or `:CodeDiff A B` -- that is where it lives;
+      -- reading HEAD or :0 yields nothing, because it is already gone there.
+      -- The HEAD/:0 case is only right for a plain explorer. Fixes #390.
+      local revision = base_revision or ((group == "staged") and "HEAD" or ":0")
 
-        -- Whenever the explorer is anchored to a base_revision (single-rev
-        -- like `:CodeDiff HEAD~5` OR revision-revision like `:CodeDiff A B`),
-        -- the deleted file's content lives at base_revision; reading from
-        -- HEAD/:0 yields nothing because the file is already gone there.
-        -- The HEAD/:0 branch is only correct for plain explorer mode
-        -- (no base_revision). Fixes #390.
-        if base_revision then
-          if is_inline then
-            require("codediff.ui.view.inline_view").show_single_file(tabpage, file_path, {
-              revision = base_revision,
-              git_root = git_root,
-              rel_path = file_path,
-              side = "original",
-            })
-          else
-            require("codediff.ui.view.side_by_side").show_deleted_virtual_file(tabpage, git_root, file_path, base_revision)
-          end
+      show_when_still_selected(explorer, file_data.path, function(is_inline)
+        if is_inline then
+          require("codediff.ui.view.inline_view").show_single_file(tabpage, file_path, {
+            revision = revision,
+            git_root = git_root,
+            rel_path = file_path,
+            side = "original",
+          })
+        elseif base_revision then
+          require("codediff.ui.view.side_by_side").show_deleted_virtual_file(tabpage, git_root, file_path, base_revision)
         else
-          if is_inline then
-            local revision = (group == "staged") and "HEAD" or ":0"
-            require("codediff.ui.view.inline_view").show_single_file(tabpage, file_path, {
-              revision = revision,
-              git_root = git_root,
-              rel_path = file_path,
-              side = "original",
-            })
-          else
-            require("codediff.ui.view.side_by_side").show_deleted_file(tabpage, git_root, file_path, abs_path, group)
-          end
+          require("codediff.ui.view.side_by_side").show_deleted_file(tabpage, git_root, file_path, abs_path, group)
         end
       end)
       return

--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -53,12 +53,40 @@ local function show_welcome_page(explorer)
   return true
 end
 
---- Run `show` on the next tick, unless the user has moved on to another file
---- by then. Every one-sided view goes through here: the explorer fires a
---- selection for each cursor movement, so a slow open must not paint over a
---- newer one.
---- @param explorer table
---- @param file_path string The file this selection was for
+--- Open a two-sided diff on the next tick, unless the user has moved on.
+--- view.update on a stale target swaps buffers under the newer one, destroys
+--- codediff:// buffers mid-load (bufhidden=wipe), and resets single_pane.
+local function open_diff_when_still_selected(ctx, sides)
+  vim.schedule(function()
+    if ctx.explorer.current_file_path ~= ctx.file_path then
+      return
+    end
+    ---@type SessionConfig
+    local session_config = {
+      git_root = ctx.git_root,
+      original = sides.original,
+      modified = sides.modified,
+      original_revision = sides.original_revision,
+      modified_revision = sides.modified_revision,
+      conflict = sides.conflict,
+    }
+    require("codediff.ui.view").update(ctx.tabpage, session_config, ctx.jump)
+  end)
+end
+
+--- conflict_ours_position names where OURS sits on screen; original_win is on
+--- the left after conflict_window.lua's win_splitmove(rightbelow=false).
+--- @return string original_rev, string modified_rev
+local function conflict_revisions()
+  if (config.options.diff.conflict_ours_position or "right") == "right" then
+    return ":3", ":2" -- THEIRS left, OURS right
+  end
+  return ":2", ":3" -- OURS left, THEIRS right
+end
+
+--- Run `show` on the next tick, unless the user has moved on. The explorer
+--- fires a selection per cursor movement, so a slow open must not paint over
+--- a newer one.
 --- @param show fun(is_inline: boolean)
 local function show_when_still_selected(explorer, file_path, show)
   vim.schedule(function()
@@ -284,8 +312,7 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
 
     -- Handle added files: only one side has the file
     if file_data.status == "A" then
-      -- An added file has no other side to compare against, so it is shown
-      -- one-sided. Which revision holds it depends on where it was added.
+      -- Which revision holds an added file depends on where it was added.
       local revision
       if base_revision and target_revision and target_revision ~= "WORKING" then
         revision = target_revision
@@ -319,11 +346,9 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
 
     -- Handle deleted files: show old content without diff
     if file_data.status == "D" then
-      -- A deleted file is shown one-sided, from wherever its content still
-      -- exists. When the explorer is anchored to a base_revision -- either
-      -- `:CodeDiff HEAD~5` or `:CodeDiff A B` -- that is where it lives;
-      -- reading HEAD or :0 yields nothing, because it is already gone there.
-      -- The HEAD/:0 case is only right for a plain explorer. Fixes #390.
+      -- With a base_revision (`:CodeDiff HEAD~5` or `:CodeDiff A B`) the
+      -- content lives there; HEAD and :0 yield nothing, the file is already
+      -- gone. HEAD/:0 is only right for a plain explorer. Fixes #390.
       local revision = base_revision or ((group == "staged") and "HEAD" or ":0")
 
       show_when_still_selected(explorer, file_data.path, function(is_inline)
@@ -411,6 +436,14 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
     end
 
     -- Use base_revision if provided, otherwise default to HEAD
+    local ctx = {
+      explorer = explorer,
+      tabpage = tabpage,
+      git_root = git_root,
+      file_path = file_path,
+      jump = jump,
+    }
+
     local target_revision_single = base_revision or "HEAD"
     git.resolve_revision(target_revision_single, git_root, function(err_resolve, commit_hash)
       if err_resolve then
@@ -421,112 +454,46 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
       end
 
       if base_revision then
-        -- Revision mode: Simple comparison of working tree vs base_revision
-        vim.schedule(function()
-          -- Ignore stale async: if a newer selection superseded us before this
-          -- scheduled callback ran, `view.update` on the old target would
-          -- clobber the newer selection (buffers get swapped, virtual buffers
-          -- with `bufhidden=wipe` get destroyed mid-load, single_pane resets).
-          if explorer.current_file_path ~= file_path then
-            return
-          end
-          ---@type SessionConfig
-          local session_config = {
-            git_root = git_root,
-            original = path.make_ref(old_path or file_path, git_root),
-            modified = path.make_ref(abs_path, git_root),
-            original_revision = commit_hash,
-            modified_revision = nil,
-          }
-          view.update(tabpage, session_config, jump)
-        end)
+        -- A renamed file is read from its old name, which is what it was
+        -- called at that revision.
+        open_diff_when_still_selected(ctx, {
+          original = path.make_ref(old_path or file_path, git_root),
+          modified = path.make_ref(abs_path, git_root),
+          original_revision = commit_hash,
+        })
       elseif group == "conflicts" then
-        -- Merge conflict: Show incoming (:3) vs current (:2), both diffed against base (:1)
-        -- Position controlled by config.diff.conflict_ours_position (absolute screen position)
-        vim.schedule(function()
-          -- Ignore stale async: see comment on the base_revision branch above.
-          if explorer.current_file_path ~= file_path then
-            return
-          end
-          -- Determine conflict buffer positions based on config
-          -- conflict_ours_position controls where :2 (OURS) appears on screen
-          local ours_position = config.options.diff.conflict_ours_position or "right"
-
-          -- After conflict_window.lua's win_splitmove(rightbelow=false):
-          -- - original_win is on LEFT
-          -- - modified_win is on RIGHT
-          local original_rev, modified_rev
-          if ours_position == "right" then
-            original_rev = ":3" -- THEIRS in original_win (LEFT)
-            modified_rev = ":2" -- OURS in modified_win (RIGHT)
-          else
-            original_rev = ":2" -- OURS in original_win (LEFT)
-            modified_rev = ":3" -- THEIRS in modified_win (RIGHT)
-          end
-
-          ---@type SessionConfig
-          local session_config = {
-            git_root = git_root,
-            original = path.make_ref(file_path, git_root),
-            modified = path.make_ref(file_path, git_root),
-            original_revision = original_rev,
-            modified_revision = modified_rev,
-            conflict = true,
-          }
-          view.update(tabpage, session_config, jump)
-        end)
+        local original_rev, modified_rev = conflict_revisions()
+        open_diff_when_still_selected(ctx, {
+          original = path.make_ref(file_path, git_root),
+          modified = path.make_ref(file_path, git_root),
+          original_revision = original_rev,
+          modified_revision = modified_rev,
+          conflict = true,
+        })
       elseif group == "staged" then
-        -- Staged changes: Compare staged (:0) vs HEAD (both virtual)
-        -- For renames: old_path in HEAD, new path in staging
-        -- No pre-fetching needed, virtual files will load via BufReadCmd
-        vim.schedule(function()
-          -- Ignore stale async: see comment on the base_revision branch above.
-          if explorer.current_file_path ~= file_path then
-            return
-          end
-          ---@type SessionConfig
-          local session_config = {
-            git_root = git_root,
-            original = path.make_ref(old_path or file_path, git_root), -- Use old_path if rename
-            modified = path.make_ref(file_path, git_root), -- New path after rename
-            original_revision = commit_hash,
-            modified_revision = ":0",
-          }
-          view.update(tabpage, session_config, jump)
-        end)
+        -- Index against HEAD. On a rename the two sides have different names.
+        open_diff_when_still_selected(ctx, {
+          original = path.make_ref(old_path or file_path, git_root),
+          modified = path.make_ref(file_path, git_root),
+          original_revision = commit_hash,
+          modified_revision = ":0",
+        })
       else
-        -- Unstaged changes: Compare working tree vs staged (if exists) or HEAD
-        -- Check if file is in staged list
+        -- Working tree against the index when the file has staged content,
+        -- against HEAD when it does not.
         local is_staged = false
-        -- Use current status_result from explorer object
-        local current_status = explorer.status_result or status_result
-        for _, staged_file in ipairs(current_status.staged) do
+        for _, staged_file in ipairs((explorer.status_result or status_result).staged) do
           if staged_file.path == file_path then
             is_staged = true
             break
           end
         end
 
-        local original_revision = is_staged and ":0" or commit_hash
-
-        -- No pre-fetching needed, buffers will load content
-        vim.schedule(function()
-          -- Ignore stale async: if a newer selection superseded us before this
-          -- scheduled callback ran, `view.update` on the old target would
-          -- clobber the newer one (resetting single_pane, layout.arrange).
-          if explorer.current_file_path ~= file_path then
-            return
-          end
-          ---@type SessionConfig
-          local session_config = {
-            git_root = git_root,
-            original = path.make_ref(file_path, git_root),
-            modified = path.make_ref(abs_path, git_root),
-            original_revision = original_revision,
-            modified_revision = nil,
-          }
-          view.update(tabpage, session_config, jump)
-        end)
+        open_diff_when_still_selected(ctx, {
+          original = path.make_ref(file_path, git_root),
+          modified = path.make_ref(abs_path, git_root),
+          original_revision = is_staged and ":0" or commit_hash,
+        })
       end
     end)
   end

--- a/lua/codediff/ui/lifecycle/session.lua
+++ b/lua/codediff/ui/lifecycle/session.lua
@@ -58,9 +58,7 @@ end
 M.compute_virtual_uri = compute_virtual_uri
 
 --- What a layout produces once it has opened its panes and computed a diff.
---- Everything else a session needs is copied from the SessionConfig it was
---- asked to open, so a change to that shape lands in one place rather than at
---- every call site.
+--- Everything else is copied from the SessionConfig it was asked to open.
 --- @class SessionPanes
 --- @field original_bufnr number
 --- @field modified_bufnr number

--- a/lua/codediff/ui/view/helpers.lua
+++ b/lua/codediff/ui/view/helpers.lua
@@ -6,8 +6,6 @@ local path = require("codediff.core.path")
 
 --- True when the panel opens before any file is chosen, so the panes start
 --- empty and the panel fills them on first selection.
---- Shared by both layouts: they disagree about how many panes to open, not
---- about when there is nothing to show yet.
 --- @param session_config SessionConfig
 --- @return boolean
 function M.is_panel_placeholder(session_config)

--- a/lua/codediff/ui/view/init.lua
+++ b/lua/codediff/ui/view/init.lua
@@ -62,11 +62,9 @@ function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
     return require("codediff.ui.view.inline_view").update(tabpage, session_config, auto_scroll_to_first_hunk)
   end
 
-  -- A conflicted file forces side-by-side, but the tab may still be shaped for
-  -- inline: one pane, with both sides pointing at it. Handing that to the
-  -- side-by-side code makes it write both sides into the same window, so the
-  -- second overwrites the first and no result pane is ever opened. Reshape the
-  -- tab first; side_by_side.update opens the missing pane itself.
+  -- An inline tab has one pane with both sides pointing at it; side-by-side
+  -- would write both into that window. Reshape it first -- side_by_side.update
+  -- opens the missing pane itself.
   local session = lifecycle.get_session(tabpage)
   if session_config and session_config.conflict and session and session.layout == "inline" then
     require("codediff.ui.view.toggle").normalize_side_by_side_layout(tabpage)

--- a/lua/codediff/ui/view/inline_view.lua
+++ b/lua/codediff/ui/view/inline_view.lua
@@ -215,9 +215,8 @@ local function load_visible_side(win, info, is_virtual)
 end
 
 --- Materialise the original side, which inline never puts in a window.
---- A virtual original cannot use :edit — codediff:// buffers carry
---- bufhidden=wipe, so with no window showing them they are destroyed at once.
---- It gets an empty scratch buffer that the async fetch fills instead.
+--- A codediff:// buffer carries bufhidden=wipe, so with no window showing it
+--- :edit would destroy it at once; it gets a scratch buffer instead.
 --- @param info table From prepare_buffer; info.bufnr is updated in place
 --- @param is_virtual boolean
 local function load_hidden_original(info, is_virtual)

--- a/lua/codediff/ui/view/readiness.lua
+++ b/lua/codediff/ui/view/readiness.lua
@@ -1,23 +1,12 @@
--- Waiting for both sides of a diff to arrive.
---
--- A diff needs the original and the modified content together, and each side
--- arrives on its own schedule: one may come from a git fetch, the other from a
--- BufReadCmd, and either can finish first. Whichever callback runs last is the
--- one that must start the render -- but a callback only knows about its own
--- side, so something has to remember which sides are still outstanding.
---
--- That bookkeeping was written out by hand at four call sites, twice under the
--- name `pending` and twice under `wait_state`. This is that bookkeeping, once.
+-- Waiting for both sides of a diff to arrive. Each side comes on its own
+-- schedule -- one from a git fetch, the other from BufReadCmd, either first --
+-- so whichever callback runs last has to start the render.
 
 local M = {}
 
 --- Wait for every named side, then run `on_ready` exactly once.
----
---- Names are arbitrary labels; the caller reports each one as it lands. An
---- empty list means nothing is outstanding, so `on_ready` runs immediately.
---- Reporting the same name twice, or a name that was never awaited, does
---- nothing -- so a duplicated event cannot render twice.
----
+--- An empty list runs it immediately. Reporting a name twice, or one that was
+--- never awaited, does nothing, so a duplicated event cannot render twice.
 --- @param names string[] Sides to wait for, e.g. { "original", "modified" }
 --- @param on_ready function Run once every name has been reported
 --- @return table waiter With done(name) and pending()
@@ -31,9 +20,8 @@ function M.when_all(names, on_ready)
     end
   end
 
-  -- Reporting a name removes it from `outstanding`, so a side can only be
-  -- counted once and this can only reach zero once. No separate "already ran"
-  -- flag: nothing can get past the check above to need one.
+  -- Reporting a name removes it, so the count can only reach zero once. No
+  -- "already ran" flag: nothing can get past that to need one.
   local function fire_if_ready()
     if remaining > 0 then
       return

--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -277,10 +277,8 @@ local function render_diff_view(ctx)
   end
 end
 
---- Run `render` once both panes hold their final content.
---- Virtual buffers load asynchronously via BufReadCmd, so wait for the load
---- event for each virtual side; real files only need the pending :edit to
---- finish.
+--- Run `render` once both panes hold their final content. Virtual buffers
+--- load asynchronously via BufReadCmd; real files only need the pending :edit.
 --- @param tabpage number
 --- @param original_info table
 --- @param modified_info table
@@ -412,9 +410,8 @@ end
 ---@param auto_scroll_to_first_hunk boolean?
 ---@return boolean
 --- Put one side's content into `win` during an update, reusing the buffer when
---- it is still alive and re-editing when it is not.
---- Unlike load_side, used on create, this also has to cope with the buffer
---- having been wiped since the session was built.
+--- it is still alive. Unlike load_side, this has to cope with the buffer having
+--- been wiped since the session was built.
 --- @param win number
 --- @param info table From prepare_buffer; info.bufnr is updated in place
 --- @param is_virtual boolean

--- a/lua/codediff/ui/view/toggle.lua
+++ b/lua/codediff/ui/view/toggle.lua
@@ -36,11 +36,9 @@ local function normalize_inline_layout(tabpage)
   return true
 end
 
---- Reshape a tab so the side-by-side code can work on it: one pane, and a
---- session that says so. side_by_side.update opens the second pane itself when
---- it sees single_pane.
---- Exported because conflict mode needs it too: a conflicted file forces the
---- side-by-side layout, and an inline tab is not in a shape it can use.
+--- Reshape a tab to one pane and a session that says so; side_by_side.update
+--- opens the second pane itself when it sees single_pane.
+--- Exported because conflict mode needs it too.
 --- @param tabpage number
 --- @return boolean
 function M.normalize_side_by_side_layout(tabpage)

--- a/tests/ui/conflict/inline_tab_conflict_spec.lua
+++ b/tests/ui/conflict/inline_tab_conflict_spec.lua
@@ -1,14 +1,7 @@
--- A conflicted file forces the side-by-side layout, but the tab it lands in
--- may be shaped for inline: one pane, with both sides pointing at it.
---
--- Selecting a conflicted file from the explorer goes through view.update, and
--- the side-by-side code assumed it had two panes to write into. It wrote both
--- sides into the same window -- THEIRS overwrote OURS -- and never opened the
--- result pane. The user saw one window of THEIRS, no conflict markers, and no
--- keymaps to resolve anything.
---
--- Opening the same file with :CodeDiff was fine, because that path goes
--- through create, which builds the tab from scratch.
+-- A conflicted file forces the side-by-side layout, but the tab may still be
+-- shaped for inline: one pane, both sides pointing at it. side_by_side.update
+-- then wrote both into that window, THEIRS overwriting OURS, and never opened
+-- the result pane. :CodeDiff was fine; it goes through create.
 
 local h = dofile("tests/helpers.lua")
 

--- a/tests/ui/explorer/file_select_branches_spec.lua
+++ b/tests/ui/explorer/file_select_branches_spec.lua
@@ -1,0 +1,158 @@
+-- Two branches of the explorer's file-select handler had no coverage: a file
+-- added in the revision being viewed, and directory comparison mode. Stubbing
+-- either left all 90 specs green.
+--
+-- Both are about to be lifted out of a 350-line closure, so they are pinned
+-- first.
+
+local h = dofile("tests/helpers.lua")
+
+local function open_explorer_on(dir, focus_file)
+  local lifecycle = require("codediff.ui.lifecycle")
+  lifecycle.cleanup_all()
+  if focus_file then
+    vim.cmd("edit " .. vim.fn.fnameescape(dir .. "/" .. focus_file))
+  end
+  vim.cmd("CodeDiff")
+  local tabpage, explorer
+  local ready = vim.wait(15000, function()
+    for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+      local e = lifecycle.get_panel_view(tp)
+      if e and e.winid and vim.api.nvim_win_is_valid(e.winid) then
+        tabpage, explorer = tp, e
+        return true
+      end
+    end
+    return false
+  end, 50)
+  assert.is_true(ready, "explorer should open")
+  return tabpage, explorer
+end
+
+describe("explorer file select: added files", function()
+  local repo, saved_cwd
+
+  before_each(function()
+    h.ensure_plugin_loaded()
+    saved_cwd = vim.fn.getcwd()
+    repo = h.create_temp_git_repo()
+    repo.write_file("kept.txt", { "k1", "k2" })
+    repo.git("add -A")
+    repo.git("commit -qm base")
+    -- Added and staged, so the explorer lists it under Staged Changes with
+    -- status "A" rather than as untracked.
+    repo.write_file("added.txt", { "new1", "new2", "new3" })
+    repo.git("add added.txt")
+    vim.cmd("cd " .. vim.fn.fnameescape(repo.dir))
+  end)
+
+  after_each(function()
+    if saved_cwd and vim.fn.isdirectory(saved_cwd) == 1 then
+      pcall(vim.cmd, "cd " .. vim.fn.fnameescape(saved_cwd))
+    end
+    require("codediff.ui.lifecycle").cleanup_all()
+    if repo then
+      repo.cleanup()
+    end
+    while vim.fn.tabpagenr("$") > 1 do
+      vim.cmd("tabclose!")
+    end
+  end)
+
+  it("shows the added file's contents, not an empty diff", function()
+    local tabpage, explorer = open_explorer_on(repo.dir, "kept.txt")
+
+    explorer.current_file_path = "added.txt"
+    explorer.on_file_select({
+      path = "added.txt",
+      status = "A",
+      group = "staged",
+      git_root = repo.dir,
+    }, {})
+
+    local lifecycle = require("codediff.ui.lifecycle")
+    assert.is_true(
+      vim.wait(15000, function()
+        local s = lifecycle.get_session(tabpage)
+        if not (s and s.modified_bufnr and vim.api.nvim_buf_is_valid(s.modified_bufnr)) then
+          return false
+        end
+        local text = table.concat(vim.api.nvim_buf_get_lines(s.modified_bufnr, 0, -1, false), "\n")
+        return text:find("new1", 1, true) ~= nil
+      end, 50),
+      "an added file must show its staged contents"
+    )
+
+    -- An added file has nothing to compare against, so it is shown one-sided.
+    local session = lifecycle.get_session(tabpage)
+    assert.is_not_nil(session.single_side, "an added file should render as a single side")
+  end)
+end)
+
+describe("explorer file select: directory comparison", function()
+  local dir_a, dir_b, saved_cwd
+
+  before_each(function()
+    h.ensure_plugin_loaded()
+    saved_cwd = vim.fn.getcwd()
+    dir_a = h.create_temp_dir()
+    dir_b = h.create_temp_dir()
+    vim.fn.writefile({ "left1", "same" }, dir_a .. "/f.txt")
+    vim.fn.writefile({ "right1", "same" }, dir_b .. "/f.txt")
+  end)
+
+  after_each(function()
+    if saved_cwd and vim.fn.isdirectory(saved_cwd) == 1 then
+      pcall(vim.cmd, "cd " .. vim.fn.fnameescape(saved_cwd))
+    end
+    require("codediff.ui.lifecycle").cleanup_all()
+    for _, d in ipairs({ dir_a, dir_b }) do
+      if d then
+        vim.fn.delete(d, "rf")
+      end
+    end
+    while vim.fn.tabpagenr("$") > 1 do
+      vim.cmd("tabclose!")
+    end
+  end)
+
+  it("diffs the two directories' copies of the file", function()
+    local lifecycle = require("codediff.ui.lifecycle")
+    lifecycle.cleanup_all()
+    vim.cmd("CodeDiff dir " .. vim.fn.fnameescape(dir_a) .. " " .. vim.fn.fnameescape(dir_b))
+
+    local tabpage, explorer
+    assert.is_true(
+      vim.wait(15000, function()
+        for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+          local e = lifecycle.get_panel_view(tp)
+          if e and e.winid and vim.api.nvim_win_is_valid(e.winid) then
+            tabpage, explorer = tp, e
+            return true
+          end
+        end
+        return false
+      end, 50),
+      "directory explorer should open"
+    )
+
+    explorer.current_file_path = "f.txt"
+    explorer.on_file_select({ path = "f.txt", status = "M", group = "unstaged" }, {})
+
+    assert.is_true(
+      vim.wait(15000, function()
+        local s = lifecycle.get_session(tabpage)
+        if not (s and s.original_bufnr and s.modified_bufnr) then
+          return false
+        end
+        if not (vim.api.nvim_buf_is_valid(s.original_bufnr) and vim.api.nvim_buf_is_valid(s.modified_bufnr)) then
+          return false
+        end
+        local left = table.concat(vim.api.nvim_buf_get_lines(s.original_bufnr, 0, -1, false), "\n")
+        local right = table.concat(vim.api.nvim_buf_get_lines(s.modified_bufnr, 0, -1, false), "\n")
+        return left:find("left1", 1, true) ~= nil and right:find("right1", 1, true) ~= nil
+      end, 50),
+      "each side must come from its own directory"
+    )
+  end)
+end)

--- a/tests/ui/explorer/file_select_branches_spec.lua
+++ b/tests/ui/explorer/file_select_branches_spec.lua
@@ -1,9 +1,6 @@
 -- Two branches of the explorer's file-select handler had no coverage: a file
 -- added in the revision being viewed, and directory comparison mode. Stubbing
 -- either left all 90 specs green.
---
--- Both are about to be lifted out of a 350-line closure, so they are pinned
--- first.
 
 local h = dofile("tests/helpers.lua")
 

--- a/tests/ui/explorer/revision_explorer_spec.lua
+++ b/tests/ui/explorer/revision_explorer_spec.lua
@@ -1,0 +1,92 @@
+-- Opening the explorer against a revision -- `:CodeDiff HEAD~1` -- takes its
+-- own branch of the file-select handler. That branch had no coverage.
+--
+-- What distinguishes it from the fallback is renames: it reads the left side
+-- from the file's *old* path, because that is what the file was called at that
+-- revision. The fallback uses the current name, which does not exist there, so
+-- the left side comes back empty.
+--
+-- An unrenamed file cannot tell the two apart -- both resolve the same commit
+-- -- so the rename is the test. It has to be a rename git will actually
+-- report as one: `-M` needs the two versions to still look alike, so the file
+-- is long enough that changing one line leaves it recognisable.
+
+local h = dofile("tests/helpers.lua")
+
+describe("explorer opened against a revision", function()
+  local repo, saved_cwd
+
+  before_each(function()
+    h.ensure_plugin_loaded()
+    saved_cwd = vim.fn.getcwd()
+    repo = h.create_temp_git_repo()
+    repo.write_file("before.txt", { "l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8", "OLD" })
+    repo.git("add -A")
+    repo.git("commit -qm first")
+    repo.git("mv before.txt after.txt")
+    repo.write_file("after.txt", { "l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8", "RENAMED" })
+    repo.git("add -A")
+    repo.git("commit -qm renamed")
+    repo.write_file("after.txt", { "l1", "l2", "l3", "l4", "l5", "l6", "l7", "l8", "WORKING" })
+    vim.cmd("cd " .. vim.fn.fnameescape(repo.dir))
+  end)
+
+  after_each(function()
+    if saved_cwd and vim.fn.isdirectory(saved_cwd) == 1 then
+      pcall(vim.cmd, "cd " .. vim.fn.fnameescape(saved_cwd))
+    end
+    require("codediff.ui.lifecycle").cleanup_all()
+    if repo then
+      repo.cleanup()
+    end
+    while vim.fn.tabpagenr("$") > 1 do
+      vim.cmd("tabclose!")
+    end
+  end)
+
+  it("reads a renamed file's left side from its old name", function()
+    local lifecycle = require("codediff.ui.lifecycle")
+    lifecycle.cleanup_all()
+
+    -- Assert on the explorer's own first selection: :CodeDiff HEAD~1 opens and
+    -- selects a file by itself, and a hand-made select afterwards would only
+    -- repeat work already done.
+    vim.cmd("CodeDiff HEAD~1")
+
+    local tabpage
+    assert.is_true(
+      vim.wait(15000, function()
+        for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+          local e = lifecycle.get_panel_view(tp)
+          if e and e.winid and vim.api.nvim_win_is_valid(e.winid) then
+            local s = lifecycle.get_session(tp)
+            if s and s.original_bufnr and s.modified_bufnr and vim.api.nvim_buf_is_valid(s.original_bufnr) and vim.api.nvim_buf_is_valid(s.modified_bufnr) then
+              -- Wait for content, not for the session: the diff result is set
+              -- before both sides have finished loading.
+              local l = table.concat(vim.api.nvim_buf_get_lines(s.original_bufnr, 0, -1, false), "\n")
+              local r = table.concat(vim.api.nvim_buf_get_lines(s.modified_bufnr, 0, -1, false), "\n")
+              if #l > 0 and r:find("WORKING", 1, true) then
+                tabpage = tp
+                return true
+              end
+            end
+          end
+        end
+        return false
+      end, 50),
+      "revision explorer should open with both sides loaded"
+    )
+
+    local session = lifecycle.get_session(tabpage)
+    local left = table.concat(vim.api.nvim_buf_get_lines(session.original_bufnr, 0, -1, false), "\n")
+    local right = table.concat(vim.api.nvim_buf_get_lines(session.modified_bufnr, 0, -1, false), "\n")
+
+    h.assert_contains(right, "WORKING", "right side should be the working tree")
+
+    -- The left side is read from before.txt, the name the file had at HEAD~1.
+    -- Reading after.txt there finds nothing, and an empty left side is exactly
+    -- what that looks like.
+    h.assert_contains(left, "OLD", "left side must hold the file's content at HEAD~1")
+    assert.equals("before.txt", session.original.relative, "left side must be read from the old name")
+  end)
+end)

--- a/tests/ui/explorer/revision_explorer_spec.lua
+++ b/tests/ui/explorer/revision_explorer_spec.lua
@@ -1,15 +1,9 @@
--- Opening the explorer against a revision -- `:CodeDiff HEAD~1` -- takes its
--- own branch of the file-select handler. That branch had no coverage.
---
--- What distinguishes it from the fallback is renames: it reads the left side
--- from the file's *old* path, because that is what the file was called at that
--- revision. The fallback uses the current name, which does not exist there, so
--- the left side comes back empty.
---
--- An unrenamed file cannot tell the two apart -- both resolve the same commit
--- -- so the rename is the test. It has to be a rename git will actually
--- report as one: `-M` needs the two versions to still look alike, so the file
--- is long enough that changing one line leaves it recognisable.
+-- `:CodeDiff HEAD~1` takes its own branch of the file-select handler, which
+-- had no coverage. What separates it from the fallback is renames: it reads
+-- the left side from the file's old name, which is what it was called at that
+-- revision. An unrenamed file cannot tell the two apart, so the rename is the
+-- test -- and it has to be one `-M` will report, hence a file long enough to
+-- stay recognisable after an edit.
 
 local h = dofile("tests/helpers.lua")
 
@@ -48,9 +42,8 @@ describe("explorer opened against a revision", function()
     local lifecycle = require("codediff.ui.lifecycle")
     lifecycle.cleanup_all()
 
-    -- Assert on the explorer's own first selection: :CodeDiff HEAD~1 opens and
-    -- selects a file by itself, and a hand-made select afterwards would only
-    -- repeat work already done.
+    -- Assert on the explorer's own first selection: a hand-made select
+    -- afterwards would only repeat work already done.
     vim.cmd("CodeDiff HEAD~1")
 
     local tabpage
@@ -83,9 +76,8 @@ describe("explorer opened against a revision", function()
 
     h.assert_contains(right, "WORKING", "right side should be the working tree")
 
-    -- The left side is read from before.txt, the name the file had at HEAD~1.
-    -- Reading after.txt there finds nothing, and an empty left side is exactly
-    -- what that looks like.
+    -- before.txt is the name the file had at HEAD~1; reading after.txt there
+    -- finds nothing, which is what an empty left side looks like.
     h.assert_contains(left, "OLD", "left side must hold the file's content at HEAD~1")
     assert.equals("before.txt", session.original.relative, "left side must be read from the old name")
   end)

--- a/tests/ui/lifecycle/placeholder_paths_spec.lua
+++ b/tests/ui/lifecycle/placeholder_paths_spec.lua
@@ -1,11 +1,7 @@
--- A placeholder session stores the two paths as the empty string, while every
--- other session stores them as Path tables. Everything that reads them reaches
--- for .absolute or .relative, and Lua lets you index a string, so those reads
--- quietly returned nil instead of failing. Nothing checked the nil, so it
--- worked by coincidence rather than by design.
---
--- Both sides are the empty Path now. This pins that: a placeholder session must
--- carry the same shape as any other, so a reader cannot tell them apart.
+-- A placeholder session stored its paths as the empty string while every other
+-- session stored Path tables. Readers reach for .absolute, and Lua lets you
+-- index a string, so those reads answered nil instead of failing. Both are
+-- path.empty() now; this pins that.
 
 local h = dofile("tests/helpers.lua")
 

--- a/tests/ui/view/pane_setup_spec.lua
+++ b/tests/ui/view/pane_setup_spec.lua
@@ -1,9 +1,6 @@
 -- Window setup done by side_by_side.create: which pane lands on which side,
--- and the window options both panes get.
---
--- Both were uncovered — stubbing the split-direction choice and dropping the
--- window-option loop each left the whole suite green — and both are about to
--- move during the create() decomposition.
+-- and the window options both panes get. Both were uncovered -- stubbing
+-- either left the whole suite green.
 
 local h = dofile("tests/helpers.lua")
 local path = require("codediff.core.path")

--- a/tests/ui/view/readiness_spec.lua
+++ b/tests/ui/view/readiness_spec.lua
@@ -1,9 +1,6 @@
--- Waiting for both sides of a diff to arrive.
---
--- This bookkeeping used to be written out at three call sites, twice under the
--- name `pending` and once as a table keyed by buffer number. Each copy could
--- drift, and one of them did: keying by buffer number meant that when both
--- sides shared a buffer, one arrival was counted as two.
+-- Waiting for both sides of a diff to arrive. This bookkeeping used to be
+-- written out at three call sites, one of which keyed by buffer number and so
+-- counted a single arrival twice when both sides shared a buffer.
 
 local readiness = require("codediff.ui.view.readiness")
 


### PR DESCRIPTION
## Summary

`explorer/render.lua` had 669 lines and four functions; `M.create` was 587 of them, holding sixteen nested closures at up to eight levels deep. The revision handling I edited for the conflict fix last week sat at level six.

```
M.create   587 -> 493 lines
render.lua 669 -> 630 lines
```

## What the explorer does here

The file list on the left. Selecting a file opens its diff, and what that means depends on the file:

| | |
|---|---|
| modified | old version left, new version right |
| untracked | nothing to compare against, one pane |
| added | one pane, from whichever revision holds it |
| deleted | one pane, from wherever the content still exists |
| conflicted | OURS and THEIRS, both against the base |

Each of those cases wrote out the same scaffolding around its one real decision: schedule to the next tick, check the user has not moved to another file, look up the layout, dispatch. Two helpers now hold that scaffolding — `show_when_still_selected` for one-sided views, `open_diff_when_still_selected` for two-sided ones — and each case says only what it decides.

The added and deleted cases each had the layout check written twice, once per revision arm. They now choose a revision, then dispatch once.

## Three branches had no coverage

Stubbing any of these left the whole suite green:

- a file **added** in the revision being viewed
- **directory comparison** mode
- the **revision-anchored** select (`:CodeDiff HEAD~1`)

All three were about to move, so they were pinned first. The third took several attempts to write: it differs from the fallback only in that it reads a renamed file from its *old* name, and a rename git will actually report as one needs the two versions to still resemble each other. A short file renamed and edited comes through as an add plus a delete and lands in a different branch entirely.

I first concluded that branch was dead code. That was wrong twice over — the test scenario did not reach it, and the mutation I used to check landed on one of the three identical `old_path or file_path` lines in a *different* branch. It is live, and dropping `old_path` within it now fails a spec.

## Comment trim

The last three PRs left 19% of their comment blocks at four lines or more, against 7% for the rest of `lua/`. 41 lines cut. What went was restating the code, or narrating how it came to be — history that belongs in the commit that made it. What stayed answers why: why a stale selection must be dropped, why a deleted file reads from `base_revision` (#390), why `:edit` cannot be used on a windowless `codediff://` buffer.

`readiness.lua` lost the most: a ten-line header explaining the problem, followed by a nine-line docstring explaining it again.

## Testing

92 specs green. Behaviour compared before and after across six scenarios — modified, untracked, added, deleted, directory comparison, and a revision-mode rename — recording layout, `single_side`, window count, both buffers' contents and the diff size. Identical except for commit hashes, which differ per run.
