### PR TITLE
refactor(history): lift the recursive tree walks out of their callbacks

### DIFF
--- a/lua/codediff/ui/history/render.lua
+++ b/lua/codediff/ui/history/render.lua
@@ -95,6 +95,19 @@ end
 -- tabpage: tabpage handle
 -- width: optional width override
 -- opts: { range, path, ... } original options
+--- Expand every directory node under `node_ids`, recursively.
+--- @param tree table
+--- @param node_ids table
+local function expand_directories(tree, node_ids)
+  for _, node_id in ipairs(node_ids) do
+    local node = tree:get_node(node_id)
+    if node and node.data and node.data.type == "directory" then
+      node:expand()
+      expand_directories(tree, node:get_child_ids() or {})
+    end
+  end
+end
+
 --- First file node under `node_ids`, expanding directories on the way down.
 --- @param tree table
 --- @param node_ids table
@@ -268,16 +281,7 @@ function M.create(commits, git_root, tabpage, width, opts)
 
         -- Auto-expand all directory nodes in tree mode
         if view_mode == "tree" then
-          local function expand_directories(node_ids)
-            for _, node_id in ipairs(node_ids) do
-              local node = tree:get_node(node_id)
-              if node and node.data and node.data.type == "directory" then
-                node:expand()
-                expand_directories(node:get_child_ids() or {})
-              end
-            end
-          end
-          expand_directories(commit_node:get_child_ids() or {})
+          expand_directories(tree, commit_node:get_child_ids() or {})
         end
 
         commit_node:expand()

--- a/lua/codediff/ui/history/render.lua
+++ b/lua/codediff/ui/history/render.lua
@@ -95,6 +95,28 @@ end
 -- tabpage: tabpage handle
 -- width: optional width override
 -- opts: { range, path, ... } original options
+--- First file node under `node_ids`, expanding directories on the way down.
+--- @param tree table
+--- @param node_ids table
+--- @return table|nil
+local function find_first_file(tree, node_ids)
+  for _, node_id in ipairs(node_ids) do
+    local node = tree:get_node(node_id)
+    if node and node.data then
+      if node.data.type == "file" then
+        return node
+      elseif node.data.type == "directory" then
+        node:expand()
+        local child_file = find_first_file(tree, node:get_child_ids() or {})
+        if child_file then
+          return child_file
+        end
+      end
+    end
+  end
+  return nil
+end
+
 function M.create(commits, git_root, tabpage, width, opts)
   opts = opts or {}
   local base_revision = opts.base_revision
@@ -365,47 +387,26 @@ function M.create(commits, git_root, tabpage, width, opts)
   if first_commit_node then
     vim.schedule(function()
       if is_single_file_mode then
-        -- Single file mode: directly select the file at first commit
-        -- Use file_path from commit data if available (handles renames), fallback to opts.file_path
-        local file_path = first_commit_node.data.file_path or opts.file_path
-        local file_data = {
-          path = file_path,
+        -- file_path from the commit rather than opts, so a rename resolves to
+        -- the name the file had at that commit.
+        history.on_file_select({
+          path = first_commit_node.data.file_path or opts.file_path,
           commit_hash = first_commit_node.data.hash,
           git_root = git_root,
-        }
-        history.on_file_select(file_data)
-      else
-        -- Multi-file mode: expand first commit and select first file
-        load_commit_files(first_commit_node, function()
-          if first_commit_node:has_children() then
-            -- Find first file node (may need to traverse directories in tree mode)
-            local function find_first_file(node_ids)
-              for _, node_id in ipairs(node_ids) do
-                local node = tree:get_node(node_id)
-                if node and node.data then
-                  if node.data.type == "file" then
-                    return node
-                  elseif node.data.type == "directory" then
-                    -- Expand directory and search its children
-                    node:expand()
-                    local child_file = find_first_file(node:get_child_ids() or {})
-                    if child_file then
-                      return child_file
-                    end
-                  end
-                end
-              end
-              return nil
-            end
-
-            local first_file = find_first_file(first_commit_node:get_child_ids() or {})
-            if first_file and first_file.data then
-              tree:render()
-              history.on_file_select(first_file.data)
-            end
-          end
-        end)
+        })
+        return
       end
+
+      load_commit_files(first_commit_node, function()
+        if not first_commit_node:has_children() then
+          return
+        end
+        local first_file = find_first_file(tree, first_commit_node:get_child_ids() or {})
+        if first_file and first_file.data then
+          tree:render()
+          history.on_file_select(first_file.data)
+        end
+      end)
     end)
   end
 

--- a/tests/ui/history/history_commit_files_spec.lua
+++ b/tests/ui/history/history_commit_files_spec.lua
@@ -1,0 +1,99 @@
+-- What the history panel lists under a commit.
+--
+-- history_file_filter_spec covers filter.apply itself; this covers whether the
+-- history panel calls it. Removing the filter call left the whole suite green.
+
+local h = dofile("tests/helpers.lua")
+h.ensure_plugin_loaded()
+
+--- Expand the newest commit and return the panel's rendered lines.
+--- Commits load their files on demand, through the same entry point the <CR>
+--- mapping and the refresh watcher use.
+local function expand_newest_commit()
+  local lifecycle = require("codediff.ui.lifecycle")
+  local history
+  local opened = vim.wait(15000, function()
+    for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+      local view = lifecycle.get_panel_view(tp)
+      if view and view._load_commit_files and view.tree then
+        history = view
+        return true
+      end
+    end
+    return false
+  end, 50)
+  if not opened then
+    return nil
+  end
+
+  local commit_node
+  for _, node in ipairs(history.tree:get_nodes()) do
+    if node.data and node.data.type == "commit" then
+      commit_node = node
+      break
+    end
+  end
+  if not commit_node then
+    return nil
+  end
+
+  local done = false
+  history._load_commit_files(commit_node, function()
+    done = true
+  end)
+  if not vim.wait(10000, function()
+    return done
+  end, 50) then
+    return nil
+  end
+  vim.wait(300)
+
+  local _, buf = h.find_window_by_filetype("codediff-history")
+  if not (buf and vim.api.nvim_buf_is_valid(buf)) then
+    return nil
+  end
+  return table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
+end
+
+describe("history panel file list", function()
+  local repo, saved_cwd
+
+  before_each(function()
+    saved_cwd = vim.fn.getcwd()
+    repo = h.create_temp_git_repo()
+    -- git names a commit's files by diffing against its parent, so the commit
+    -- under test needs one before it.
+    vim.fn.writefile({ "base" }, repo.dir .. "/base.txt")
+    repo.git("add .")
+    repo.git("commit -m base")
+  end)
+
+  after_each(function()
+    if saved_cwd and vim.fn.isdirectory(saved_cwd) == 1 then
+      pcall(vim.cmd, "cd " .. vim.fn.fnameescape(saved_cwd))
+    end
+    h.close_extra_tabs()
+    if repo then
+      repo.cleanup()
+    end
+  end)
+
+  it("hides files matching explorer.file_filter.ignore", function()
+    vim.fn.mkdir(repo.dir .. "/dist", "p")
+    vim.fn.writefile({ "keep me" }, repo.dir .. "/kept.txt")
+    vim.fn.writefile({ "built" }, repo.dir .. "/dist/bundle.js")
+    repo.git("add .")
+    repo.git("commit -m second")
+
+    require("codediff").setup({ explorer = { file_filter = { ignore = { "dist/**" } } } })
+
+    vim.cmd("cd " .. vim.fn.fnameescape(repo.dir))
+    vim.cmd("CodeDiff history")
+
+    local text = expand_newest_commit()
+    assert.is_not_nil(text, "history panel should render an expanded commit")
+
+    h.assert_contains(text, "kept.txt", "an unfiltered file should be listed")
+    assert.is_nil(text:find("bundle.js", 1, true), "an ignored file must not be listed")
+  end)
+end)

--- a/tests/ui/history/history_initial_file_spec.lua
+++ b/tests/ui/history/history_initial_file_spec.lua
@@ -1,0 +1,94 @@
+-- Opening the history panel selects the newest commit's first file by itself,
+-- so the diff pane is not left empty. In tree view that file may sit inside a
+-- directory node, which has to be expanded to reach it.
+--
+-- Neither had coverage: stubbing the selection, or the directory expansion,
+-- left the whole suite green.
+
+local h = dofile("tests/helpers.lua")
+h.ensure_plugin_loaded()
+
+--- Wait until the history tab has a diff session with content on both sides.
+local function wait_for_diff(timeout)
+  local lifecycle = require("codediff.ui.lifecycle")
+  local tabpage
+  local ok = vim.wait(timeout or 15000, function()
+    for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+      local s = lifecycle.get_session(tp)
+      if s and s.modified_bufnr and vim.api.nvim_buf_is_valid(s.modified_bufnr) then
+        local text = table.concat(vim.api.nvim_buf_get_lines(s.modified_bufnr, 0, -1, false), "\n")
+        if #vim.trim(text) > 0 then
+          tabpage = tp
+          return true
+        end
+      end
+    end
+    return false
+  end, 50)
+  return ok, tabpage
+end
+
+describe("history opens on a file", function()
+  local repo, saved_cwd
+
+  before_each(function()
+    require("codediff").setup({})
+    saved_cwd = vim.fn.getcwd()
+    repo = h.create_temp_git_repo()
+  end)
+
+  after_each(function()
+    if saved_cwd and vim.fn.isdirectory(saved_cwd) == 1 then
+      pcall(vim.cmd, "cd " .. vim.fn.fnameescape(saved_cwd))
+    end
+    h.close_extra_tabs()
+    if repo then
+      repo.cleanup()
+    end
+  end)
+
+  it("selects the newest commit's file without being asked", function()
+    repo.write_file("file.txt", { "version 1" })
+    repo.git("add .")
+    repo.git("commit -m first")
+    repo.write_file("file.txt", { "VERSION 2" })
+    repo.git("add .")
+    repo.git("commit -m second")
+
+    vim.cmd("cd " .. vim.fn.fnameescape(repo.dir))
+    vim.cmd("edit " .. repo.path("file.txt"))
+    vim.cmd("CodeDiff history")
+
+    local ok, tabpage = wait_for_diff()
+    assert.is_true(ok, "history should open a diff on the first file by itself")
+
+    local session = require("codediff.ui.lifecycle").get_session(tabpage)
+    local modified = table.concat(vim.api.nvim_buf_get_lines(session.modified_bufnr, 0, -1, false), "\n")
+    h.assert_contains(modified, "VERSION 2", "should show the newest commit's content")
+  end)
+
+  it("reaches a file nested in a directory", function()
+    -- The first file of this commit is under a directory, so the tree has to
+    -- expand it before there is a file node to select.
+    vim.fn.mkdir(repo.dir .. "/src/deep", "p")
+    vim.fn.writefile({ "nested one" }, repo.dir .. "/src/deep/nested.txt")
+    repo.git("add .")
+    repo.git("commit -m first")
+    vim.fn.writefile({ "NESTED TWO" }, repo.dir .. "/src/deep/nested.txt")
+    repo.git("add .")
+    repo.git("commit -m second")
+
+    require("codediff").setup({ history = { view_mode = "tree" } })
+
+    vim.cmd("cd " .. vim.fn.fnameescape(repo.dir))
+    vim.cmd("edit " .. repo.dir .. "/src/deep/nested.txt")
+    vim.cmd("CodeDiff history")
+
+    local ok, tabpage = wait_for_diff()
+    assert.is_true(ok, "history should walk into directories to find a file")
+
+    local session = require("codediff.ui.lifecycle").get_session(tabpage)
+    local modified = table.concat(vim.api.nvim_buf_get_lines(session.modified_bufnr, 0, -1, false), "\n")
+    h.assert_contains(modified, "NESTED TWO", "should show the nested file's newest content")
+  end)
+end)


### PR DESCRIPTION
## Summary

`history/render.lua` had the deepest nesting in the repository — eleven levels — from two recursive tree walks defined inside callbacks:

```
M.create
  if first_commit_node
    vim.schedule
      load_commit_files(..., function()
        if has_children
          local function find_first_file   <- level 11
```

Both walks need only the tree, so both are module-level functions now.

```
deepest nesting   11 -> 6 levels
M.create          333 -> 304 lines
```

## What is not changed

`load_commit_files` and `on_file_select` stay inside `M.create`. They close over `tree`, `history`, `git_root` and `base_revision`; lifting them means passing all of that explicitly, which makes the call sites worse than the nesting did. The two recursive walks were different — they take a tree and nothing else.

The remaining 304 lines are a straight line: build the window, build the tree, assemble the object, define the two callbacks, wire up keymaps and refresh. Cutting that into pieces would mean jumping between them to read what happens in order.

## Coverage first

Both walks were unreachable by any test. Stubbing the first-file search, or the directory expansion, left the whole suite green. Two specs were added before either moved:

- the history panel selects the newest commit's first file by itself, including when that file sits inside a directory node
- the file list under a commit honours `explorer.file_filter.ignore` — `history_file_filter_spec` covers `filter.apply` itself, nothing covered whether history calls it

Each fails against its own mutation.

## A note on method

Several mutation checks during this branch reported "not caught" when the mutation had never been applied: the script matched on an indentation that did not exist and `str.replace` returns the string unchanged rather than raising. I deleted one working spec on the strength of that, and elsewhere today concluded a live branch was dead code.

The script now exits non-zero when the pattern is missing, and also when it matches more than once — which immediately caught a case where the intended line appeared twice and the mutation would have landed on the wrong one.

## Testing

94 specs green. The two new specs fail against their mutations; the four earlier ones on this file still pass.
