### PR TITLE
test(explorer): pin the flicker guard, then simplify it

### DIFF
--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -151,6 +151,22 @@ local function already_showing(session, explorer, file_path, abs_path, group)
   return staged == base_is_index
 end
 
+--- Expand every directory node beneath `node`, recursively.
+--- @param tree table
+--- @param node table
+local function expand_directories(tree, node)
+  if not node:has_children() then
+    return
+  end
+  for _, child_id in ipairs(node:get_child_ids()) do
+    local child = tree:get_node(child_id)
+    if child and child.data and child.data.type == "directory" then
+      child:expand()
+      expand_directories(tree, child)
+    end
+  end
+end
+
 local function show_when_still_selected(explorer, file_path, show)
   vim.schedule(function()
     if explorer.current_file_path ~= file_path then
@@ -237,17 +253,6 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
 
   -- Expand all groups by default before first render
   -- In tree mode, also expand all directories
-  local function expand_nodes_recursive(nodes)
-    for _, node in ipairs(nodes) do
-      if node.data and (node.data.type == "group" or node.data.type == "directory") then
-        node:expand()
-        if node:has_children() then
-          expand_nodes_recursive(node:get_child_ids())
-        end
-      end
-    end
-  end
-
   -- get_child_ids returns IDs, need to get actual nodes
   for _, node in ipairs(tree_data) do
     if node.data and node.data.type == "group" then
@@ -256,23 +261,10 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
   end
 
   -- For tree mode, expand directories after initial render when we have node IDs
-  local explorer_config = config.options.explorer or {}
   if explorer_config.view_mode == "tree" then
-    -- We need to expand directory nodes - they're children of group nodes
-    local function expand_all_dirs(parent_node)
-      if not parent_node:has_children() then
-        return
-      end
-      for _, child_id in ipairs(parent_node:get_child_ids()) do
-        local child = tree:get_node(child_id)
-        if child and child.data and child.data.type == "directory" then
-          child:expand()
-          expand_all_dirs(child)
-        end
-      end
-    end
+    -- Directory nodes hang off the group nodes expanded above.
     for _, node in ipairs(tree_data) do
-      expand_all_dirs(node)
+      expand_directories(tree, node)
     end
   end
 
@@ -329,33 +321,23 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
       local original = path.make_ref(file_path, explorer.dir1)
       local modified = path.make_ref(file_path, explorer.dir2)
 
-      -- Check if already displaying same file
       local session = lifecycle.get_session(tabpage)
-      if
-        not opts.force
-        and session
+      local showing_already = session
         and session.original
         and session.modified
         and session.original.absolute == original.absolute
         and session.modified.absolute == modified.absolute
-      then
+      if showing_already and not opts.force then
         return
       end
 
-      vim.schedule(function()
-        if explorer.current_file_path ~= file_path then
-          return
-        end
-        ---@type SessionConfig
-        local session_config = {
-          git_root = nil,
-          original = original,
-          modified = modified,
-          original_revision = nil,
-          modified_revision = nil,
-        }
-        view.update(tabpage, session_config, jump)
-      end)
+      open_diff_when_still_selected({
+        explorer = explorer,
+        tabpage = tabpage,
+        git_root = nil,
+        file_path = file_path,
+        jump = jump,
+      }, { original = original, modified = modified })
       return
     end
 

--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -88,10 +88,8 @@ end
 --- fires a selection per cursor movement, so a slow open must not paint over
 --- a newer one.
 --- @param show fun(is_inline: boolean)
---- Is `file_path` staged right now, according to the explorer's last status?
---- Returns nil when there is no status to consult.
---- @param explorer table
---- @param file_path string
+--- Whether `file_path` is staged, per the explorer's last status.
+--- nil when there is no status to consult.
 --- @return boolean|nil
 local function has_staged_changes(explorer, file_path)
   local status = explorer.status_result
@@ -106,16 +104,8 @@ local function has_staged_changes(explorer, file_path)
   return false
 end
 
---- True when the session already shows exactly this comparison, so opening it
---- again would only reset the cursor and repaint.
----
---- The explorer fires a selection on every refresh, and a repaint triggers the
---- next refresh: that loop is the flicker behind #317 and #401.
----
---- @param session table
---- @param explorer table
---- @param file_path string Path as the explorer names it
---- @param abs_path string Absolute path
+--- True when the session already shows exactly this comparison. Opening it
+--- again only repaints, and the repaint fires the next refresh: #317, #401.
 --- @param group string "staged" | "unstaged" | "conflicts"
 --- @return boolean
 local function already_showing(session, explorer, file_path, abs_path, group)
@@ -124,14 +114,14 @@ local function already_showing(session, explorer, file_path, abs_path, group)
     return false
   end
 
-  -- Conflict revisions :2/:3 are mutable, so the staged-base check below would
-  -- see a change on every refresh and rebuild forever.
+  -- :2/:3 are mutable, so the staged-base check below would see a change on
+  -- every refresh and rebuild forever.
   if group == "conflicts" then
     return session.result_win ~= nil and vim.api.nvim_win_is_valid(session.result_win)
   end
 
-  -- Staged and unstaged views of one file compare against different things,
-  -- so the same path is not the same diff.
+  -- The two views compare against different things, so the same path is not
+  -- the same diff.
   if (group == "staged") ~= (session.modified_revision == ":0") then
     return false
   end
@@ -140,9 +130,8 @@ local function already_showing(session, explorer, file_path, abs_path, group)
     return true
   end
 
-  -- An unstaged view compares against :0 once the file has staged content and
-  -- against HEAD before that, so the base moves when staging does. With no
-  -- status to consult there is nothing to say it moved.
+  -- Unstaged compares against :0 once the file has staged content, HEAD before
+  -- that. No status to consult means nothing says the base moved.
   local staged = has_staged_changes(explorer, file_path)
   if staged == nil then
     return true
@@ -152,8 +141,6 @@ local function already_showing(session, explorer, file_path, abs_path, group)
 end
 
 --- Expand every directory node beneath `node`, recursively.
---- @param tree table
---- @param node table
 local function expand_directories(tree, node)
   if not node:has_children() then
     return

--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -88,6 +88,69 @@ end
 --- fires a selection per cursor movement, so a slow open must not paint over
 --- a newer one.
 --- @param show fun(is_inline: boolean)
+--- Is `file_path` staged right now, according to the explorer's last status?
+--- Returns nil when there is no status to consult.
+--- @param explorer table
+--- @param file_path string
+--- @return boolean|nil
+local function has_staged_changes(explorer, file_path)
+  local status = explorer.status_result
+  if not status then
+    return nil
+  end
+  for _, staged_file in ipairs(status.staged or {}) do
+    if staged_file.path == file_path then
+      return true
+    end
+  end
+  return false
+end
+
+--- True when the session already shows exactly this comparison, so opening it
+--- again would only reset the cursor and repaint.
+---
+--- The explorer fires a selection on every refresh, and a repaint triggers the
+--- next refresh: that loop is the flicker behind #317 and #401.
+---
+--- @param session table
+--- @param explorer table
+--- @param file_path string Path as the explorer names it
+--- @param abs_path string Absolute path
+--- @param group string "staged" | "unstaged" | "conflicts"
+--- @return boolean
+local function already_showing(session, explorer, file_path, abs_path, group)
+  local same_file = (session.modified and session.modified.absolute == abs_path) or (session.original and session.original.absolute == abs_path)
+  if not same_file then
+    return false
+  end
+
+  -- Conflict revisions :2/:3 are mutable, so the staged-base check below would
+  -- see a change on every refresh and rebuild forever.
+  if group == "conflicts" then
+    return session.result_win ~= nil and vim.api.nvim_win_is_valid(session.result_win)
+  end
+
+  -- Staged and unstaged views of one file compare against different things,
+  -- so the same path is not the same diff.
+  if (group == "staged") ~= (session.modified_revision == ":0") then
+    return false
+  end
+
+  if group == "staged" then
+    return true
+  end
+
+  -- An unstaged view compares against :0 once the file has staged content and
+  -- against HEAD before that, so the base moves when staging does. With no
+  -- status to consult there is nothing to say it moved.
+  local staged = has_staged_changes(explorer, file_path)
+  if staged == nil then
+    return true
+  end
+  local base_is_index = session.original_revision ~= nil and session.original_revision:match("^:[0-3]$") ~= nil
+  return staged == base_is_index
+end
+
 local function show_when_still_selected(explorer, file_path, show)
   vim.schedule(function()
     if explorer.current_file_path ~= file_path then
@@ -371,48 +434,8 @@ function M.create(status_result, git_root, tabpage, width, base_revision, target
     -- Check if this exact diff is already being displayed
     -- Same file can have different diffs (staged vs HEAD, working vs staged)
     local session = lifecycle.get_session(tabpage)
-    if session then
-      local is_same_file = (session.modified and session.modified.absolute == abs_path) or (session.original and session.original.absolute == abs_path)
-
-      if is_same_file and not opts.force then
-        -- Conflict mode: skip if already showing the same conflict file
-        -- (revisions :2/:3 are mutable so the staged-base-change logic below
-        --  would incorrectly force a re-render on every refresh cycle)
-        if group == "conflicts" and session.result_win and vim.api.nvim_win_is_valid(session.result_win) then
-          return
-        end
-
-        -- Check if it's the same diff comparison
-        local is_staged_diff = group == "staged"
-        local current_is_staged = session.modified_revision == ":0"
-
-        if is_staged_diff == current_is_staged then
-          -- Same diff type — but also check if comparison base changed
-          -- (e.g. unstaged file gains staged changes: HEAD → :0)
-          if group ~= "staged" then
-            local current_status = explorer.status_result
-            if current_status then
-              local file_has_staged = false
-              for _, sf in ipairs(current_status.staged or {}) do
-                if sf.path == file_path then
-                  file_has_staged = true
-                  break
-                end
-              end
-              local current_is_mutable = session.original_revision and session.original_revision:match("^:[0-3]$")
-              if file_has_staged ~= (current_is_mutable and true or false) then
-                -- Comparison base needs to change — don't skip
-              else
-                return
-              end
-            else
-              return
-            end
-          else
-            return
-          end
-        end
-      end
+    if session and not opts.force and already_showing(session, explorer, file_path, abs_path, group) then
+      return
     end
 
     if base_revision and target_revision and target_revision ~= "WORKING" then

--- a/tests/ui/explorer/reselect_spec.lua
+++ b/tests/ui/explorer/reselect_spec.lua
@@ -1,9 +1,5 @@
--- Re-selecting the file already on screen must not rebuild the diff.
---
--- The explorer fires a selection on every refresh, and rebuilding resets the
--- cursor and repaints, which fires another refresh: the "flicker" of #317 and
--- #401. The guard that stops it had no test -- removing it left the whole suite
--- green, because nothing counted rebuilds.
+-- Re-selecting the file already on screen must not rebuild the diff: the
+-- rebuild repaints, the repaint fires another refresh. That is #317 and #401.
 
 local h = dofile("tests/helpers.lua")
 h.ensure_plugin_loaded()
@@ -121,14 +117,9 @@ describe("explorer re-selection", function()
   end)
 
   it("rebuilds an unstaged view once the file gains staged content", function()
-    -- An unstaged view compares against HEAD until the file has staged
-    -- content, then against :0. Staging moves that base, so the diff on screen
-    -- is no longer the one being asked for -- even though the file, the group
-    -- and the staged/unstaged type are all unchanged.
-    --
-    -- The staging is faked on the explorer's own status rather than run
-    -- through git, because a real `git add` wakes the refresh watcher and it
-    -- would rebuild on its own, which proves nothing about this guard.
+    -- Staging moves the comparison base from HEAD to :0, so the diff changes
+    -- even though file, group and type do not. Staged on the explorer's own
+    -- status: a real `git add` wakes the watcher, which rebuilds by itself.
     local explorer = open_explorer()
 
     select(explorer, "a.txt")

--- a/tests/ui/explorer/reselect_spec.lua
+++ b/tests/ui/explorer/reselect_spec.lua
@@ -1,0 +1,162 @@
+-- Re-selecting the file already on screen must not rebuild the diff.
+--
+-- The explorer fires a selection on every refresh, and rebuilding resets the
+-- cursor and repaints, which fires another refresh: the "flicker" of #317 and
+-- #401. The guard that stops it had no test -- removing it left the whole suite
+-- green, because nothing counted rebuilds.
+
+local h = dofile("tests/helpers.lua")
+h.ensure_plugin_loaded()
+
+describe("explorer re-selection", function()
+  local repo, saved_cwd, restore_update, updates
+
+  before_each(function()
+    saved_cwd = vim.fn.getcwd()
+    repo = h.create_temp_git_repo()
+    repo.write_file("a.txt", { "a1", "a2" })
+    repo.write_file("b.txt", { "b1", "b2" })
+    repo.git("add -A")
+    repo.git("commit -qm base")
+    repo.write_file("a.txt", { "a1", "A2 CHANGED" })
+    repo.write_file("b.txt", { "b1", "B2 CHANGED" })
+
+    local view = require("codediff.ui.view")
+    local original = view.update
+    updates = 0
+    view.update = function(...)
+      updates = updates + 1
+      return original(...)
+    end
+    restore_update = function()
+      view.update = original
+    end
+  end)
+
+  after_each(function()
+    if restore_update then
+      restore_update()
+    end
+    if saved_cwd and vim.fn.isdirectory(saved_cwd) == 1 then
+      pcall(vim.cmd, "cd " .. vim.fn.fnameescape(saved_cwd))
+    end
+    require("codediff.ui.lifecycle").cleanup_all()
+    if repo then
+      repo.cleanup()
+    end
+    while vim.fn.tabpagenr("$") > 1 do
+      vim.cmd("tabclose!")
+    end
+  end)
+
+  local function open_explorer()
+    local lifecycle = require("codediff.ui.lifecycle")
+    lifecycle.cleanup_all()
+    vim.cmd("cd " .. vim.fn.fnameescape(repo.dir))
+    vim.cmd("CodeDiff")
+    local explorer
+    assert.is_true(
+      vim.wait(15000, function()
+        for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+          local e = lifecycle.get_panel_view(tp)
+          if e and e.winid and vim.api.nvim_win_is_valid(e.winid) then
+            explorer = e
+            return true
+          end
+        end
+        return false
+      end, 50),
+      "explorer should open"
+    )
+    vim.wait(2000)
+    return explorer
+  end
+
+  local function select(explorer, file)
+    explorer.current_file_path = file
+    explorer.on_file_select({ path = file, status = "M", group = "unstaged", git_root = repo.dir }, {})
+    vim.wait(250)
+  end
+
+  it("does not rebuild the diff for the file already shown", function()
+    local explorer = open_explorer()
+
+    local before = updates
+    for _ = 1, 10 do
+      select(explorer, "a.txt")
+    end
+    vim.wait(1000)
+
+    assert.equals(before, updates, "re-selecting the same file must not rebuild the diff")
+  end)
+
+  it("still rebuilds when the file changes", function()
+    local explorer = open_explorer()
+
+    select(explorer, "a.txt")
+    vim.wait(1500)
+    local before = updates
+
+    select(explorer, "b.txt")
+    vim.wait(1500)
+
+    assert.is_true(updates > before, "selecting a different file must rebuild the diff")
+  end)
+
+  it("rebuilds when the same file moves between staged and unstaged", function()
+    -- The two views compare against different things -- :0 for staged, HEAD
+    -- for unstaged -- so the same path is not the same diff.
+    local explorer = open_explorer()
+
+    select(explorer, "a.txt")
+    vim.wait(1500)
+    local before = updates
+
+    repo.git("add a.txt")
+    explorer.current_file_path = "a.txt"
+    explorer.on_file_select({ path = "a.txt", status = "M", group = "staged", git_root = repo.dir }, {})
+    vim.wait(1500)
+
+    assert.is_true(updates > before, "moving to the staged view must rebuild the diff")
+  end)
+
+  it("rebuilds an unstaged view once the file gains staged content", function()
+    -- An unstaged view compares against HEAD until the file has staged
+    -- content, then against :0. Staging moves that base, so the diff on screen
+    -- is no longer the one being asked for -- even though the file, the group
+    -- and the staged/unstaged type are all unchanged.
+    --
+    -- The staging is faked on the explorer's own status rather than run
+    -- through git, because a real `git add` wakes the refresh watcher and it
+    -- would rebuild on its own, which proves nothing about this guard.
+    local explorer = open_explorer()
+
+    select(explorer, "a.txt")
+    vim.wait(1500)
+    local before = updates
+
+    explorer.status_result = {
+      staged = { { path = "a.txt" } },
+      unstaged = { { path = "a.txt" } },
+      conflicts = {},
+    }
+    select(explorer, "a.txt")
+    vim.wait(1500)
+
+    assert.is_true(updates > before, "staging moves the comparison base, so the diff must rebuild")
+  end)
+
+  it("rebuilds when asked to force", function()
+    local explorer = open_explorer()
+
+    select(explorer, "a.txt")
+    vim.wait(1500)
+    local before = updates
+
+    explorer.current_file_path = "a.txt"
+    explorer.on_file_select({ path = "a.txt", status = "M", group = "unstaged", git_root = repo.dir }, { force = true })
+    vim.wait(1500)
+
+    assert.is_true(updates > before, "force must rebuild even for the same file")
+  end)
+end)


### PR DESCRIPTION
## Summary

The explorer fires a file selection on every refresh. Rebuilding the diff resets the cursor and repaints, and the repaint triggers the next refresh — that loop is the flicker of #317 and #401. The guard that breaks it grew over six months and five commits, and had no test.

```
M.create        494 -> 419 lines
deepest         9 -> 6 levels
specs           94 -> 95 files
```

## The guard now has tests

Removing it entirely left all 94 specs green, so I first read that as "flicker cannot be tested headless". That was wrong, and the correction is the useful part of this PR: **flicker is repeated rebuilding, and rebuilds are countable.**

```
with the guard      re-select the same file 10x ->  0 rebuilds
without the guard   re-select the same file 10x -> 10 rebuilds
```

Five specs, one per arm:

| | |
|---|---|
| same file | rebuilds nothing |
| different file | rebuilds |
| staged ↔ unstaged view | rebuilds — the two compare against different things |
| file gains staged content | rebuilds — the base moves from HEAD to `:0` |
| `force` | rebuilds regardless |

Each fails against its own mutation. The last one stages on the explorer's own status rather than running `git add`: a real `git add` wakes the refresh watcher, which rebuilds on its own and makes the assertion prove nothing.

## Then the guard itself

Five nested conditions ending in an empty `if` branch whose only purpose was to not take the `else`:

```lua
if file_has_staged ~= (current_is_mutable and true or false) then
  -- Comparison base needs to change — don't skip
else
  return
end
```

It answers one question — is this comparison already on screen — so it is a function that returns that, and the call site is three lines. Behaviour is preserved down to the case where the explorer has no status to consult: the old code skipped, and so does this.

## Dead code and a duplicate

`expand_nodes_recursive` was defined and never called. It also passed `get_child_ids()` — a list of IDs — to a loop that treated them as nodes, so it would not have worked if it had been.

`expand_all_dirs` was a second recursive walk defined inside `M.create`, like the two in `history/render.lua` last week. It needs only the tree, so it is `expand_directories` at module level.

The directory-comparison branch open-coded the schedule, the stale-selection check and the `view.update` that `open_diff_when_still_selected` already holds.

A second `local explorer_config` shadowed the first with an identical value.

## What is left alone

`on_file_select` is still 207 lines, but it is a flat run of early returns — directory mode, untracked, added, deleted, already-shown, two-revision, otherwise — each nine to fifty lines, nothing nested. Cutting it up would mean jumping between pieces to read what happens in order.

Last week I split `keymaps.lua`'s 186-line function into a table and it came out 23 lines *longer*; that was reverted. Length is not the signal — depth is.

## Testing

95 specs green. Behaviour compared before and after across six scenarios — modified, untracked, added, deleted, directory comparison and a revision-mode rename — recording layout, `single_side`, window count, both buffers' contents and the diff size: **byte-identical**.
