### PR TITLE
refactor(explorer): name what a refresh decides, and reattach seven comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,4 @@ bump-prerelease:
 help:
 	@echo "Targets: build, test, test-c, test-lua, lint, clean, help"
 	@echo "Version: bump-patch, bump-minor, bump-major, bump-prerelease"
+	@echo "Checks:  scripts/find_orphan_comments.py --rev main..HEAD"

--- a/lua/codediff/ui/explorer/refresh.lua
+++ b/lua/codediff/ui/explorer/refresh.lua
@@ -98,7 +98,6 @@ function M.setup_auto_refresh(explorer, tabpage)
   return cleanup
 end
 
--- Collect collapsed state from tree (groups and directories that user manually collapsed)
 --- Walk every group and directory node beneath `root_nodes`, calling `visit`
 --- with the node and the key it is remembered by.
 --- @param visit fun(node: table, key: string)
@@ -151,9 +150,6 @@ local function restore_collapsed_state(tree, collapsed, root_nodes)
   end)
 end
 
--- Rebuild the explorer tree from a status_result and re-render, honoring the
--- current group visibility. Runs synchronously (no vim.schedule), so callers in
--- a normal context — e.g. toggling a group — get an immediately consistent tree.
 --- The reviewed file's slot in its group, read off the status from before the
 --- refresh. file_to_reselect needs it to find whatever takes that slot.
 --- @param explorer table
@@ -235,6 +231,9 @@ local function file_to_reselect(explorer, status_result, prev_index)
   return nil, nil
 end
 
+-- Rebuild the explorer tree from a status_result and re-render, honoring the
+-- current group visibility. Runs synchronously (no vim.schedule), so callers in
+-- a normal context — e.g. toggling a group — get an immediately consistent tree.
 local function rebuild_tree(explorer, status_result, collapsed_state)
   local root_nodes = tree_module.create_tree_data(status_result, explorer.git_root, explorer.base_revision, not explorer.git_root, explorer.visible_groups)
 

--- a/lua/codediff/ui/explorer/refresh.lua
+++ b/lua/codediff/ui/explorer/refresh.lua
@@ -165,6 +165,87 @@ end
 -- Rebuild the explorer tree from a status_result and re-render, honoring the
 -- current group visibility. Runs synchronously (no vim.schedule), so callers in
 -- a normal context — e.g. toggling a group — get an immediately consistent tree.
+--- The reviewed file's slot in its group, read off the status from before the
+--- refresh. file_to_reselect needs it to find whatever takes that slot.
+--- @param explorer table
+--- @return number|nil
+local function reviewed_file_index(explorer)
+  local group = explorer.current_file_group
+  if not group then
+    return nil
+  end
+  for i, f in ipairs((explorer.status_result or {})[group] or {}) do
+    if f.path == explorer.current_file_path then
+      return i
+    end
+  end
+  return nil
+end
+
+--- Forget which file was being reviewed, panel selection included.
+--- @param explorer table
+local function clear_current_file(explorer)
+  explorer.current_file_path = nil
+  explorer.current_file_group = nil
+  explorer.current_selection = nil
+  if explorer.clear_selection then
+    explorer.clear_selection()
+  end
+end
+
+--- Which file the explorer should show after a refresh, and in which group.
+---
+--- Prefer the same group the reviewer was in: hunk staging leaves the file
+--- where it was. When the file left that group entirely -- fully staged or
+--- unstaged -- take whatever now occupies its slot there, so staging walks
+--- down the unstaged list instead of chasing the file into the staged one
+--- (#347). Only if the group has nothing left does the search follow the file.
+---
+--- @param explorer table
+--- @param status_result table
+--- @param prev_index number? The file's slot in its group before the refresh
+--- @return table|nil file, string|nil group
+local function file_to_reselect(explorer, status_result, prev_index)
+  local group_lists = {
+    unstaged = status_result.unstaged,
+    staged = status_result.staged,
+    conflicts = status_result.conflicts,
+  }
+  local current_group = explorer.current_file_group
+
+  local function search(files, group_name)
+    for _, f in ipairs(files or {}) do
+      if f.path == explorer.current_file_path then
+        return f, group_name
+      end
+    end
+    return nil, nil
+  end
+
+  if current_group then
+    local found, group = search(group_lists[current_group], current_group)
+    if found then
+      return found, group
+    end
+  end
+
+  if current_group and prev_index then
+    local same_group = group_lists[current_group]
+    if same_group and #same_group > 0 then
+      return same_group[math.min(prev_index, #same_group)], current_group
+    end
+  end
+
+  for _, group_name in ipairs({ "conflicts", "unstaged", "staged" }) do
+    local found, group = search(status_result[group_name], group_name)
+    if found then
+      return found, group
+    end
+  end
+
+  return nil, nil
+end
+
 local function rebuild_tree(explorer, status_result, collapsed_state)
   local root_nodes = tree_module.create_tree_data(status_result, explorer.git_root, explorer.base_revision, not explorer.git_root, explorer.visible_groups)
 
@@ -240,31 +321,9 @@ function M.refresh(explorer)
       -- Rebuild tree nodes (honors group visibility) and re-render.
       rebuild_tree(explorer, status_result, collapsed_state)
 
-      -- #347: remember the reviewed file's slot in its group (from the previous
-      -- status) so re-selection can advance to whatever replaces it after a
-      -- full stage/unstage, instead of chasing the file into another group.
-      local prev_group = explorer.current_file_group
-      local prev_index = nil
-      if prev_group then
-        for i, f in ipairs((explorer.status_result or {})[prev_group] or {}) do
-          if f.path == explorer.current_file_path then
-            prev_index = i
-            break
-          end
-        end
-      end
-
-      -- Update status result for file selection logic
+      -- Read before status_result is replaced below.
+      local prev_index = reviewed_file_index(explorer)
       explorer.status_result = status_result
-
-      local function clear_current_file()
-        explorer.current_file_path = nil
-        explorer.current_file_group = nil
-        explorer.current_selection = nil
-        if explorer.clear_selection then
-          explorer.clear_selection()
-        end
-      end
 
       local show_welcome_page = require("codediff.ui.explorer.render").show_welcome_page
 
@@ -274,7 +333,7 @@ function M.refresh(explorer)
         local lifecycle = require("codediff.ui.lifecycle")
         local session = lifecycle.get_session(explorer.tabpage)
         local already_welcome = session and welcome.is_welcome_buffer(session.modified_bufnr)
-        clear_current_file()
+        clear_current_file(explorer)
         if not already_welcome then
           show_welcome_page(explorer)
         end
@@ -285,51 +344,10 @@ function M.refresh(explorer)
       -- If found (possibly in a new group), call on_file_select to update diff panes.
       -- If not found (committed/removed), show welcome page.
       if explorer.current_file_path and total_files > 0 then
-        local found_file = nil
-        local found_group = nil
-        local group_lists = {
-          unstaged = status_result.unstaged,
-          staged = status_result.staged,
-          conflicts = status_result.conflicts,
-        }
-        local current_group = explorer.current_file_group
-        -- Search helper: look in a specific status list
-        local function search_group(files, group_name)
-          for _, f in ipairs(files or {}) do
-            if f.path == explorer.current_file_path then
-              return f, group_name
-            end
-          end
-          return nil, nil
-        end
-        -- Search same group first (preferred — e.g. hunk staging keeps file in same group)
-        if current_group then
-          found_file, found_group = search_group(group_lists[current_group], current_group)
-        end
-        -- #347: the reviewed file was fully staged/unstaged and left its group.
-        -- Advance to the file now occupying its slot in the SAME group — stage
-        -- jumps to the next unstaged file, unstage to the next staged file —
-        -- instead of chasing the file into another group.
-        if not found_file and current_group and prev_index then
-          local same_group = group_lists[current_group]
-          if same_group and #same_group > 0 then
-            found_file, found_group = same_group[math.min(prev_index, #same_group)], current_group
-          end
-        end
-        -- Otherwise the file moved to another group (or was resolved): follow it.
-        if not found_file then
-          found_file, found_group = search_group(status_result.conflicts, "conflicts")
-        end
-        if not found_file then
-          found_file, found_group = search_group(status_result.unstaged, "unstaged")
-        end
-        if not found_file then
-          found_file, found_group = search_group(status_result.staged, "staged")
-        end
-
+        local found_file, found_group = file_to_reselect(explorer, status_result, prev_index)
         if found_file then
-          -- Re-select current file — on_file_select guard handles deduplication
-          -- Pass no_jump to preserve cursor position (this is a refresh, not user click)
+          -- on_file_select dedupes; no_jump keeps the cursor where it is,
+          -- since this is a refresh rather than a click.
           explorer.on_file_select({
             path = found_file.path,
             old_path = found_file.old_path,
@@ -338,8 +356,8 @@ function M.refresh(explorer)
             group = found_group,
           }, { no_jump = true })
         else
-          -- File was committed/removed — show welcome
-          clear_current_file()
+          -- Committed or removed.
+          clear_current_file(explorer)
           show_welcome_page(explorer)
         end
       end

--- a/lua/codediff/ui/explorer/refresh.lua
+++ b/lua/codediff/ui/explorer/refresh.lua
@@ -216,10 +216,6 @@ function M.refresh(explorer)
     return
   end
 
-  -- Get current selection to restore it after refresh
-  local current_node = explorer.tree:get_node()
-  local current_path = current_node and current_node.data and current_node.data.path
-
   -- Collect collapsed state before async operation
   local collapsed_state = collect_collapsed_state(explorer.tree)
 

--- a/lua/codediff/ui/explorer/refresh.lua
+++ b/lua/codediff/ui/explorer/refresh.lua
@@ -99,67 +99,56 @@ function M.setup_auto_refresh(explorer, tabpage)
 end
 
 -- Collect collapsed state from tree (groups and directories that user manually collapsed)
-local function collect_collapsed_state(tree)
-  local collapsed = {}
-
-  local function collect_from_node(node)
+--- Walk every group and directory node beneath `root_nodes`, calling `visit`
+--- with the node and the key it is remembered by.
+--- @param visit fun(node: table, key: string)
+local function walk_collapsible(tree, root_nodes, visit)
+  local function walk(node)
     if not node.data then
       return
     end
     local node_type = node.data.type
-    if node_type == "group" or node_type == "directory" then
-      -- Use path for directories, name for groups as unique key
-      local key = node.data.path or node.data.name
-      if key and not node:is_expanded() then
-        collapsed[key] = true
-      end
-      -- Recurse into children
-      if node:has_children() then
-        for _, child_id in ipairs(node:get_child_ids()) do
-          local child = tree:get_node(child_id)
-          if child then
-            collect_from_node(child)
-          end
+    if node_type ~= "group" and node_type ~= "directory" then
+      return
+    end
+    -- Directories are keyed by path, groups by name.
+    local key = node.data.path or node.data.name
+    if key then
+      visit(node, key)
+    end
+    if node:has_children() then
+      for _, child_id in ipairs(node:get_child_ids()) do
+        local child = tree:get_node(child_id)
+        if child then
+          walk(child)
         end
       end
     end
   end
 
-  local root_nodes = tree:get_nodes()
   for _, node in ipairs(root_nodes) do
-    collect_from_node(node)
+    walk(node)
   end
+end
 
+--- Which collapsible nodes are collapsed, keyed for restoring later.
+local function collect_collapsed_state(tree)
+  local collapsed = {}
+  walk_collapsible(tree, tree:get_nodes(), function(node, key)
+    if not node:is_expanded() then
+      collapsed[key] = true
+    end
+  end)
   return collapsed
 end
 
--- Restore collapsed state after tree rebuild
+--- Re-collapse whatever was collapsed before the tree was rebuilt.
 local function restore_collapsed_state(tree, collapsed, root_nodes)
-  local function restore_node(node)
-    if not node.data then
-      return
+  walk_collapsible(tree, root_nodes, function(node, key)
+    if collapsed[key] then
+      node:collapse()
     end
-    local node_type = node.data.type
-    if node_type == "group" or node_type == "directory" then
-      local key = node.data.path or node.data.name
-      if key and collapsed[key] then
-        node:collapse()
-      end
-      -- Recurse into children
-      if node:has_children() then
-        for _, child_id in ipairs(node:get_child_ids()) do
-          local child = tree:get_node(child_id)
-          if child then
-            restore_node(child)
-          end
-        end
-      end
-    end
-  end
-
-  for _, node in ipairs(root_nodes) do
-    restore_node(node)
-  end
+  end)
 end
 
 -- Rebuild the explorer tree from a status_result and re-render, honoring the

--- a/lua/codediff/ui/explorer/render.lua
+++ b/lua/codediff/ui/explorer/render.lua
@@ -84,10 +84,6 @@ local function conflict_revisions()
   return ":2", ":3" -- OURS left, THEIRS right
 end
 
---- Run `show` on the next tick, unless the user has moved on. The explorer
---- fires a selection per cursor movement, so a slow open must not paint over
---- a newer one.
---- @param show fun(is_inline: boolean)
 --- Whether `file_path` is staged, per the explorer's last status.
 --- nil when there is no status to consult.
 --- @return boolean|nil
@@ -154,6 +150,10 @@ local function expand_directories(tree, node)
   end
 end
 
+--- Run `show` on the next tick, unless the user has moved on. The explorer
+--- fires a selection per cursor movement, so a slow open must not paint over
+--- a newer one.
+--- @param show fun(is_inline: boolean)
 local function show_when_still_selected(explorer, file_path, show)
   vim.schedule(function()
     if explorer.current_file_path ~= file_path then

--- a/lua/codediff/ui/history/render.lua
+++ b/lua/codediff/ui/history/render.lua
@@ -89,12 +89,6 @@ function M.build_tree_nodes(commits, git_root, opts)
   return tree_nodes
 end
 
--- Create file history panel
--- commits: array of commit objects from git.get_commit_list
--- git_root: absolute path to git repository root
--- tabpage: tabpage handle
--- width: optional width override
--- opts: { range, path, ... } original options
 --- Expand every directory node under `node_ids`, recursively.
 --- @param tree table
 --- @param node_ids table
@@ -130,6 +124,12 @@ local function find_first_file(tree, node_ids)
   return nil
 end
 
+-- Create file history panel
+-- commits: array of commit objects from git.get_commit_list
+-- git_root: absolute path to git repository root
+-- tabpage: tabpage handle
+-- width: optional width override
+-- opts: { range, path, ... } original options
 function M.create(commits, git_root, tabpage, width, opts)
   opts = opts or {}
   local base_revision = opts.base_revision

--- a/lua/codediff/ui/view/inline_view.lua
+++ b/lua/codediff/ui/view/inline_view.lua
@@ -108,10 +108,6 @@ end
 -- Create
 -- ============================================================================
 
----@param session_config SessionConfig
----@param filetype? string
----@param on_ready? function
----@return table|nil
 --- Replace a scratch buffer's contents, restoring its read-only state.
 --- Returns false when the buffer is gone, which is the caller's cue to stop:
 --- the tab may have closed while the fetch was in flight.
@@ -281,6 +277,10 @@ local function render_when_loaded(ctx, render)
   end)
 end
 
+---@param session_config SessionConfig
+---@param filetype? string
+---@param on_ready? function
+---@return table|nil
 function M.create(session_config, filetype, on_ready)
   vim.cmd("tabnew")
   local tabpage = vim.api.nvim_get_current_tabpage()

--- a/lua/codediff/ui/view/side_by_side.lua
+++ b/lua/codediff/ui/view/side_by_side.lua
@@ -38,10 +38,6 @@ local setup_all_keymaps = view_keymaps.setup_all_keymaps
 -- Create
 -- ============================================================================
 
----@param session_config SessionConfig
----@param filetype? string
----@param on_ready? function
----@return table|nil
 --- Split direction that lands the modified pane on the side the user asked for.
 --- Explicit rather than relying on 'splitright'.
 --- @return string
@@ -322,6 +318,10 @@ local function render_when_loaded(tabpage, original_info, modified_info, origina
   })
 end
 
+---@param session_config SessionConfig
+---@param filetype? string
+---@param on_ready? function
+---@return table|nil
 function M.create(session_config, filetype, on_ready)
   vim.cmd("tabnew")
   local tabpage = vim.api.nvim_get_current_tabpage()
@@ -405,10 +405,6 @@ end
 -- Update
 -- ============================================================================
 
----@param tabpage number
----@param session_config SessionConfig
----@param auto_scroll_to_first_hunk boolean?
----@return boolean
 --- Put one side's content into `win` during an update, reusing the buffer when
 --- it is still alive. Unlike load_side, this has to cope with the buffer having
 --- been wiped since the session was built.
@@ -493,6 +489,10 @@ local function render_when_reloaded(tabpage, original_info, modified_info, wait_
   })
 end
 
+---@param tabpage number
+---@param session_config SessionConfig
+---@param auto_scroll_to_first_hunk boolean?
+---@return boolean
 function M.update(tabpage, session_config, auto_scroll_to_first_hunk)
   -- Save current window to restore focus after update
   local saved_current_win = vim.api.nvim_get_current_win()

--- a/scripts/find_orphan_comments.py
+++ b/scripts/find_orphan_comments.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Find comments that were separated from the function they document.
+
+A comment becomes an orphan when something is inserted between it and its
+function -- most often while lifting a nested function to module level. The
+comment stays put, the function moves down, and the comment ends up describing
+whatever landed in the gap. Nothing fails: the code runs, the tests pass, and
+the docs quietly point at the wrong thing.
+
+Orphaned comments read exactly like correct ones, so there is no text pattern
+to look for. This looks for the *edit* that creates them instead, by walking
+the diffs:
+
+    a commit adds a `function` line,
+    and the comment lines directly above it are context, not additions
+    -> that function was inserted into someone else's comment block
+
+Two other shapes are checked the same way: a function removed or moved with its
+comment left behind, and a function renamed under a comment that stayed.
+
+Usage:
+    scripts/find_orphan_comments.py                  # every commit touching lua/
+    scripts/find_orphan_comments.py --since "1 day ago"
+    scripts/find_orphan_comments.py --rev main..HEAD  # one branch
+
+Exits non-zero when anything is found, so it can gate a commit if you want it
+to. It is not wired into CI.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+ADDED_FUNC = re.compile(r"^\+((?:local )?function\s+([\w.:]+))")
+REMOVED_FUNC = re.compile(r"^-((?:local )?function\s+([\w.:]+))")
+
+KINDS = {
+    "inserted": "a function was inserted into another function's comment block",
+    "left": "a function was removed or moved, leaving its comment behind",
+    "renamed": "a function was renamed under a comment that stayed put",
+}
+
+
+def commits(args):
+    cmd = ["git", "log", "--no-merges", "--format=%H %ad %s", "--date=short"]
+    if args.since:
+        cmd += ["--since", args.since]
+    if args.rev:
+        cmd += [args.rev]
+    cmd += ["--", args.path]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+    return [l for l in out.strip().split("\n") if l]
+
+
+def comment_lines_above(lines, index):
+    """Comment lines directly above `index`, split by how the diff marks them.
+
+    Returns (context, added, removed): lines that were already there, lines
+    this commit added, and lines it removed.
+    """
+    context, added, removed = [], [], []
+    i = index - 1
+    while i >= 0 and lines[i][:1] in " +-" and lines[i][1:].strip().startswith("--"):
+        marker, text = lines[i][0], lines[i][1:]
+        {" ": context, "+": added, "-": removed}[marker].append(text)
+        i -= 1
+    return context, added, removed
+
+
+def scan(commit_line, path):
+    sha, date, subject = commit_line.split(" ", 2)
+    show = subprocess.run(
+        ["git", "show", sha, "--unified=6", "--", path],
+        capture_output=True, text=True, check=True).stdout
+
+    found = []
+    for block in show.split("\ndiff --git ")[1:]:
+        path_match = re.search(r"b/(\S+)", block)
+        if not path_match:
+            continue
+        file_path = path_match.group(1)
+        lines = block.split("\n")
+
+        for i, line in enumerate(lines):
+            add = ADDED_FUNC.match(line)
+            remove = REMOVED_FUNC.match(line)
+            if not (add or remove):
+                continue
+
+            context, added, removed = comment_lines_above(lines, i)
+            if not context:
+                continue
+
+            if add and added:
+                kind = "inserted"
+                name = add.group(2)
+            elif remove and not removed:
+                # Renamed if another function definition appears right after.
+                following = next(
+                    (lines[k] for k in range(i + 1, min(i + 40, len(lines)))
+                     if ADDED_FUNC.match(lines[k]) or REMOVED_FUNC.match(lines[k])),
+                    "")
+                kind = "renamed" if ADDED_FUNC.match(following) else "left"
+                name = remove.group(2)
+            else:
+                continue
+
+            found.append({
+                "kind": kind, "date": date, "sha": sha[:8], "subject": subject[:52],
+                "file": file_path, "function": name, "comment": context[-1].strip(),
+            })
+    return found
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--since", help='git --since, e.g. "1 day ago"')
+    parser.add_argument("--rev", help="revision range, e.g. main..HEAD")
+    parser.add_argument("--path", default="lua/", help="path to scan (default: lua/)")
+    parser.add_argument("--kind", choices=sorted(KINDS), action="append",
+                        help="kinds to report (repeatable). Default: inserted, "
+                             "the only one with no false positives. `renamed` "
+                             "mostly catches a function moved with its comment, "
+                             "which is fine.")
+    args = parser.parse_args()
+
+    log = commits(args)
+    hits = [h for c in log for h in scan(c, args.path)]
+    hits = [h for h in hits if h["kind"] in (args.kind or ["inserted", "left"])]
+
+    for kind in sorted(KINDS):
+        rows = [h for h in hits if h["kind"] == kind]
+        if not rows:
+            continue
+        print(f"{KINDS[kind]}: {len(rows)}")
+        for h in rows:
+            print(f"  {h['date']} {h['sha']}  {h['file']}")
+            print(f"      {h['function']}")
+            print(f"      comment above: {h['comment'][:64]}")
+        print()
+
+    print(f"scanned {len(log)} commits under {args.path}")
+    if hits:
+        print(f"found {len(hits)} -- check whether the comment still describes "
+              f"the function below it")
+    else:
+        print("nothing found")
+    return 1 if hits else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ui/explorer/refresh_keeps_view_spec.lua
+++ b/tests/ui/explorer/refresh_keeps_view_spec.lua
@@ -1,0 +1,128 @@
+-- What a refresh must not disturb: a collapsed group stays collapsed, and the
+-- cursor stays on the file it was on.
+--
+-- The explorer refreshes on every write and every stage, so losing either
+-- means the panel reshuffles under the user. Both were uncovered -- stubbing
+-- the collapse capture or the cursor capture left the whole suite green.
+
+local h = dofile("tests/helpers.lua")
+h.ensure_plugin_loaded()
+
+describe("explorer refresh keeps the user's view", function()
+  local repo, saved_cwd
+
+  before_each(function()
+    require("codediff").setup({})
+    saved_cwd = vim.fn.getcwd()
+    repo = h.create_temp_git_repo()
+    repo.write_file("a.txt", { "a1" })
+    repo.write_file("b.txt", { "b1" })
+    repo.write_file("c.txt", { "c1" })
+    repo.git("add -A")
+    repo.git("commit -qm base")
+    repo.write_file("a.txt", { "A1 CHANGED" })
+    repo.write_file("b.txt", { "B1 CHANGED" })
+    repo.write_file("c.txt", { "C1 CHANGED" })
+    vim.cmd("cd " .. vim.fn.fnameescape(repo.dir))
+  end)
+
+  after_each(function()
+    if saved_cwd and vim.fn.isdirectory(saved_cwd) == 1 then
+      pcall(vim.cmd, "cd " .. vim.fn.fnameescape(saved_cwd))
+    end
+    require("codediff.ui.lifecycle").cleanup_all()
+    if repo then
+      repo.cleanup()
+    end
+    while vim.fn.tabpagenr("$") > 1 do
+      vim.cmd("tabclose!")
+    end
+  end)
+
+  local function open()
+    local lifecycle = require("codediff.ui.lifecycle")
+    lifecycle.cleanup_all()
+    vim.cmd("CodeDiff")
+    local explorer
+    assert.is_true(
+      vim.wait(15000, function()
+        for _, tp in ipairs(vim.api.nvim_list_tabpages()) do
+          local e = lifecycle.get_panel_view(tp)
+          if e and e.winid and vim.api.nvim_win_is_valid(e.winid) and e.tree then
+            explorer = e
+            return true
+          end
+        end
+        return false
+      end, 50),
+      "explorer should open"
+    )
+    vim.wait(2000)
+    return explorer
+  end
+
+  --- Nodes of a given type, top level first.
+  local function nodes_of_type(explorer, want)
+    local out = {}
+    for _, node in ipairs(explorer.tree:get_nodes()) do
+      if node.data and node.data.type == want then
+        out[#out + 1] = node
+      end
+    end
+    return out
+  end
+
+  it("leaves a collapsed group collapsed", function()
+    local explorer = open()
+
+    local groups = nodes_of_type(explorer, "group")
+    assert.is_true(#groups > 0, "explorer should have group nodes")
+
+    local target = groups[1]
+    local key = target.data.path or target.data.name
+    target:collapse()
+    explorer.tree:render()
+    vim.wait(300)
+    assert.is_false(target:is_expanded(), "the group should start out collapsed")
+
+    -- The refresh skips everything when git status is unchanged, so the tree
+    -- would never be rebuilt and the collapse would survive for the wrong
+    -- reason. Make a real change first.
+    vim.fn.writefile({ "d1 new file" }, repo.dir .. "/d.txt")
+    require("codediff.ui.explorer.refresh").refresh(explorer)
+    vim.wait(4000)
+
+    local after
+    for _, node in ipairs(explorer.tree:get_nodes()) do
+      if node.data and (node.data.path or node.data.name) == key then
+        after = node
+      end
+    end
+    assert.is_not_nil(after, "the group should still be there after a refresh")
+    assert.is_false(after:is_expanded(), "a refresh must not expand a collapsed group")
+  end)
+
+  it("advances to the file that takes its place after staging (#347)", function()
+    local explorer = open()
+
+    -- Review a.txt, the first file in the unstaged group.
+    explorer.current_file_path = "a.txt"
+    explorer.current_file_group = "unstaged"
+    explorer.on_file_select({ path = "a.txt", status = "M", group = "unstaged", git_root = repo.dir }, {})
+    vim.wait(2000)
+
+    -- Staging it moves it out of that group. Rather than chasing it into the
+    -- staged group, the refresh keeps the reviewer where they were: on
+    -- whatever file now occupies that slot.
+    repo.git("add a.txt")
+    require("codediff.ui.explorer.refresh").refresh(explorer)
+    vim.wait(4000)
+
+    assert.equals("b.txt", explorer.current_file_path, "should advance to the file taking a.txt's slot")
+
+    local lifecycle = require("codediff.ui.lifecycle")
+    local session = lifecycle.get_session(explorer.tabpage)
+    local shown = table.concat(vim.api.nvim_buf_get_lines(session.modified_bufnr, 0, -1, false), "\n")
+    h.assert_contains(shown, "B1 CHANGED", "the diff should follow to b.txt")
+  end)
+end)


### PR DESCRIPTION
## Summary

`M.refresh` in `explorer/refresh.lua` was 165 lines, 126 of them a callback defined inside it. The panel refreshes on every write and every stage, and 18 of the last six months' commits touched this file.

```
process_result  126 -> 63 lines
M.refresh       165 -> 98 lines
deepest           7 ->  6 levels
```

## Coverage first

Two things a refresh takes care to preserve had no test — stubbing either left all 96 specs green:

- a collapsed group stays collapsed
- staging the file under review advances to whatever takes its slot, rather than chasing it into the staged group (#347)

Both specs make a real change to the working tree before refreshing. Without one the refresh returns early — `git status` matches the previous tick, so the tree is never rebuilt and a collapsed group stays collapsed for the wrong reason. **The first version of these specs passed for exactly that reason and caught neither mutation.**

Writing the second one also corrected my own assumption: I expected the refresh to follow the file into the staged group, and asserted that. It failed, and the comment above the code explained why — #347 deliberately keeps the reviewer in place. I nearly "fixed" correct behaviour.

## Then the refactor

59 of `process_result`'s lines answered one question: after the status changed, which file should the panel show. Three named functions now:

| | |
|---|---|
| `reviewed_file_index` | the file's slot before the refresh |
| `file_to_reselect` | which file takes its place |
| `clear_current_file` | forget the selection |

`file_to_reselect` returns early per case rather than threading `found_file` through six reassignments, so the order the cases are tried in — same group, then the slot it vacated, then the other groups — reads off the page.

`collect_collapsed_state` and `restore_collapsed_state` were the same recursive walk written twice, differing in two lines. `walk_collapsible` takes the visitor; each caller is four lines.

Two dead lines went too: `current_node` and `current_path` were computed at the top of `M.refresh` and never read.

## Seven comments were separated from their functions

Lifting a function to module level between a comment and the function it documents leaves the comment describing whatever landed in the gap. Nothing fails — the code runs, the tests pass, the docs quietly point at the wrong thing.

Three commits here fix seven of them, from this branch and from #527, #528, #531 and #532. `M.create`'s parameter docs were sitting above `diff_split_cmd`, `set_scratch_lines` and `expand_directories` in three different files.

`scripts/find_orphan_comments.py` is how they were found, and is kept for next time. **Not wired into CI.**

Scanning the source for orphans does not work — they read exactly like correct comments. Five text heuristics over 714 functions gave nineteen reports, all false; matching identifiers named in the first comment line gave 134, also all false. Walking the diffs for the *edit* that creates them gives seven, all real. Seven seconds for all 493 commits under `lua/`.

## Testing

97 specs green. Behaviour compared before and after across four refresh scenarios — opening, selecting a file, refreshing with a collapsed group and a new file, and refreshing after staging the reviewed file — recording the panel's rendered lines, the selected path and group, and the diff pane: **byte-identical**.

Dropping the #347 advance, the index it needs, or the re-collapse each fails a spec.
