### PR TITLE
fix(explorer): serialize complete refresh cycles

### DIFF
--- a/lua/codediff/ui/auto_refresh.lua
+++ b/lua/codediff/ui/auto_refresh.lua
@@ -336,66 +336,94 @@ end
 -- Called when repository state changes. Only writes if content actually changed,
 -- which triggers TextChanged → auto_refresh recomputes diff automatically.
 -- @param tabpage number: Tabpage whose session buffers to sync
-function M.sync_mutable_buffers(tabpage)
+-- @param done function|nil: Called after every mutable target settles
+function M.sync_mutable_buffers(tabpage, done)
+  done = done or function() end
   local lifecycle = require("codediff.ui.lifecycle")
   local session = lifecycle.get_session(tabpage)
   if not session then
+    done()
     return
   end
-
-  local git = require("codediff.core.git")
 
   local function is_mutable(revision)
     return revision and revision:match("^:[0-3]$")
   end
 
-  local function sync_buffer(bufnr, revision, path)
-    if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
-      return
+  local targets = {}
+  local function add_target(side, bufnr, revision, ref)
+    local path = ref and ref.relative
+    if bufnr and vim.api.nvim_buf_is_valid(bufnr) and is_mutable(revision) and path and path ~= "" then
+      targets[#targets + 1] = {
+        side = side,
+        bufnr = bufnr,
+        revision = revision,
+        path = path,
+      }
     end
-    if not is_mutable(revision) or not path or path == "" then
-      return
-    end
+  end
+  add_target("original", session.original_bufnr, session.original_revision, session.original)
+  add_target("modified", session.modified_bufnr, session.modified_revision, session.modified)
 
-    git.get_file_content(revision, session.git_root, path, function(err, lines)
+  if #targets == 0 then
+    done()
+    return
+  end
+
+  local remaining = #targets
+  local completed = false
+  local function finish_target()
+    remaining = remaining - 1
+    if remaining == 0 and not completed then
+      completed = true
+      done()
+    end
+  end
+
+  local function still_current(target)
+    local current = lifecycle.get_session(tabpage)
+    if current ~= session then
+      return false
+    end
+    local ref = current[target.side]
+    local bufnr = current[target.side .. "_bufnr"]
+    local revision = current[target.side .. "_revision"]
+    return bufnr == target.bufnr and revision == target.revision and ref and ref.relative == target.path
+  end
+
+  local function lines_equal(bufnr, lines)
+    local current = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    if #current ~= #lines then
+      return false
+    end
+    for i = 1, #lines do
+      if current[i] ~= lines[i] then
+        return false
+      end
+    end
+    return true
+  end
+
+  local git = require("codediff.core.git")
+  for _, target in ipairs(targets) do
+    git.get_file_content(target.revision, session.git_root, target.path, function(err, lines)
       vim.schedule(function()
-        if err or not lines then
-          return
+        local can_update = not err and lines and vim.api.nvim_buf_is_valid(target.bufnr) and still_current(target)
+        if can_update and not lines_equal(target.bufnr, lines) then
+          local was_modifiable = vim.bo[target.bufnr].modifiable
+          local was_readonly = vim.bo[target.bufnr].readonly
+          vim.bo[target.bufnr].readonly = false
+          vim.bo[target.bufnr].modifiable = true
+          vim.api.nvim_buf_set_lines(target.bufnr, 0, -1, false, lines)
+          vim.bo[target.bufnr].modifiable = was_modifiable
+          vim.bo[target.bufnr].readonly = was_readonly
+          -- TextChanged doesn't fire on nowrite/nofile buffers, trigger explicitly
+          M.trigger(target.bufnr)
         end
-        if not vim.api.nvim_buf_is_valid(bufnr) then
-          return
-        end
-
-        -- Only write if content actually changed
-        local current_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-        if #current_lines == #lines then
-          local same = true
-          for i = 1, #lines do
-            if current_lines[i] ~= lines[i] then
-              same = false
-              break
-            end
-          end
-          if same then
-            return
-          end
-        end
-
-        local was_modifiable = vim.bo[bufnr].modifiable
-        local was_readonly = vim.bo[bufnr].readonly
-        vim.bo[bufnr].readonly = false
-        vim.bo[bufnr].modifiable = true
-        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
-        vim.bo[bufnr].modifiable = was_modifiable
-        vim.bo[bufnr].readonly = was_readonly
-        -- TextChanged doesn't fire on nowrite/nofile buffers, trigger explicitly
-        M.trigger(bufnr)
+        finish_target()
       end)
     end)
   end
-
-  sync_buffer(session.original_bufnr, session.original_revision, session.original.relative)
-  sync_buffer(session.modified_bufnr, session.modified_revision, session.modified.relative)
 end
 
 -- Cleanup all watched buffers

--- a/lua/codediff/ui/explorer/refresh.lua
+++ b/lua/codediff/ui/explorer/refresh.lua
@@ -7,11 +7,6 @@ local welcome = require("codediff.ui.welcome")
 -- Setup native repository watching with polling as startup/runtime fallback.
 function M.setup_auto_refresh(explorer, tabpage)
   local explorer_config = config.options.explorer or {}
-  if explorer_config.auto_refresh == false then
-    explorer._cleanup_auto_refresh = function() end
-    return
-  end
-
   local uv = vim.uv or vim.loop
   local poll_timer
   local unsubscribe
@@ -19,7 +14,8 @@ function M.setup_auto_refresh(explorer, tabpage)
   local refresh_running = false
   local refresh_pending = false
   local pending_force = false
-  local group = vim.api.nvim_create_augroup("CodeDiffExplorerRefresh_" .. tabpage, { clear = true })
+  local pending_done = {}
+  local group
 
   local function stop_polling()
     if not poll_timer then
@@ -44,25 +40,37 @@ function M.setup_auto_refresh(explorer, tabpage)
       unsubscribe()
       unsubscribe = nil
     end
+    pending_done = {}
+    explorer._request_refresh = nil
     explorer._request_auto_refresh = nil
     explorer._native_watcher_ready = nil
-    pcall(vim.api.nvim_del_augroup_by_id, group)
+    if group then
+      pcall(vim.api.nvim_del_augroup_by_id, group)
+    end
   end
 
   explorer._cleanup_auto_refresh = cleanup
 
+  local function call_done(callbacks)
+    for _, callback in ipairs(callbacks) do
+      pcall(callback)
+    end
+  end
+
   local request_refresh
-  request_refresh = function(force)
+  request_refresh = function(force, done_callbacks)
+    done_callbacks = done_callbacks or {}
     if cleaned then
       return
     end
     if refresh_running then
       refresh_pending = true
       pending_force = pending_force or force == true
+      vim.list_extend(pending_done, done_callbacks)
       return
     end
     refresh_running = true
-    M.refresh(explorer, function()
+    M._refresh_once(explorer, function()
       if cleaned then
         return
       end
@@ -71,11 +79,14 @@ function M.setup_auto_refresh(explorer, tabpage)
           return
         end
         refresh_running = false
+        call_done(done_callbacks)
         if refresh_pending then
           local force_pending = pending_force
+          local done_pending = pending_done
           refresh_pending = false
           pending_force = false
-          request_refresh(force_pending)
+          pending_done = {}
+          request_refresh(force_pending, done_pending)
         end
       end)
     end, force)
@@ -100,9 +111,18 @@ function M.setup_auto_refresh(explorer, tabpage)
     request_refresh(force)
   end
 
+  explorer._request_refresh = function(force, done)
+    request_refresh(force, done and { done } or {})
+  end
   explorer._request_auto_refresh = function()
     tick(true)
   end
+
+  if explorer_config.auto_refresh == false then
+    return cleanup
+  end
+
+  group = vim.api.nvim_create_augroup("CodeDiffExplorerRefresh_" .. tabpage, { clear = true })
 
   local function start_polling()
     if cleaned or poll_timer then
@@ -314,8 +334,8 @@ local function rebuild_tree(explorer, status_result, collapsed_state)
   explorer.tree:render()
 end
 
--- Refresh explorer with updated git status
-function M.refresh(explorer, done, force)
+-- Execute one explorer refresh. Public callers use M.refresh below.
+function M._refresh_once(explorer, done, force)
   local git = require("codediff.core.git")
   local completed = false
   local function complete()
@@ -427,6 +447,14 @@ function M.refresh(explorer, done, force)
   else
     git.get_status_with_line_stats(explorer.git_root, process_result, explorer.pathspec)
   end
+end
+
+-- Queue every refresh source through the controller installed on the explorer.
+function M.refresh(explorer, done, force)
+  if explorer and explorer._request_refresh then
+    return explorer._request_refresh(force, done)
+  end
+  return M._refresh_once(explorer, done, force)
 end
 
 -- Rebuild the tree synchronously from the cached status_result. Used when only

--- a/lua/codediff/ui/explorer/refresh.lua
+++ b/lua/codediff/ui/explorer/refresh.lua
@@ -345,6 +345,12 @@ function M.refresh(explorer, done, force)
 
   local function process_result(err, status_result)
     vim.schedule(function()
+      local lifecycle = require("codediff.ui.lifecycle")
+      if lifecycle.get_panel_view(explorer.tabpage) ~= explorer or not vim.api.nvim_win_is_valid(explorer.winid) then
+        complete()
+        return
+      end
+
       if err then
         vim.notify("Failed to refresh: " .. err, vim.log.levels.ERROR)
         complete()
@@ -370,7 +376,6 @@ function M.refresh(explorer, done, force)
       -- Show welcome page when all files are clean (skip if already showing)
       local total_files = #(status_result.unstaged or {}) + #(status_result.staged or {}) + #(status_result.conflicts or {})
       if total_files == 0 then
-        local lifecycle = require("codediff.ui.lifecycle")
         local session = lifecycle.get_session(explorer.tabpage)
         local already_welcome = session and welcome.is_welcome_buffer(session.modified_bufnr)
         clear_current_file(explorer)

--- a/lua/codediff/ui/explorer/refresh.lua
+++ b/lua/codediff/ui/explorer/refresh.lua
@@ -66,14 +66,18 @@ function M.setup_auto_refresh(explorer, tabpage)
       if cleaned then
         return
       end
-      require("codediff.ui.auto_refresh").sync_mutable_buffers(tabpage)
-      refresh_running = false
-      if refresh_pending then
-        local force_pending = pending_force
-        refresh_pending = false
-        pending_force = false
-        request_refresh(force_pending)
-      end
+      require("codediff.ui.auto_refresh").sync_mutable_buffers(tabpage, function()
+        if cleaned then
+          return
+        end
+        refresh_running = false
+        if refresh_pending then
+          local force_pending = pending_force
+          refresh_pending = false
+          pending_force = false
+          request_refresh(force_pending)
+        end
+      end)
     end, force)
   end
 

--- a/tests/ui/auto_refresh_spec.lua
+++ b/tests/ui/auto_refresh_spec.lua
@@ -1,0 +1,150 @@
+describe("mutable revision synchronization", function()
+  local original_auto_refresh
+  local original_git
+  local original_lifecycle
+  local auto_refresh
+  local original_trigger
+  local current_session
+  local callbacks
+  local trigger_count
+  local original_bufnr
+  local modified_bufnr
+  local tabpage
+
+  before_each(function()
+    original_auto_refresh = package.loaded["codediff.ui.auto_refresh"]
+    original_git = package.loaded["codediff.core.git"]
+    original_lifecycle = package.loaded["codediff.ui.lifecycle"]
+
+    original_bufnr = vim.api.nvim_create_buf(false, true)
+    modified_bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(original_bufnr, 0, -1, false, { "old original" })
+    vim.api.nvim_buf_set_lines(modified_bufnr, 0, -1, false, { "old modified" })
+    tabpage = vim.api.nvim_get_current_tabpage()
+    current_session = {
+      git_root = "/repo",
+      original_bufnr = original_bufnr,
+      modified_bufnr = modified_bufnr,
+      original_revision = ":2",
+      modified_revision = ":3",
+      original = { relative = "file.txt" },
+      modified = { relative = "file.txt" },
+    }
+    callbacks = {}
+    trigger_count = 0
+
+    package.loaded["codediff.ui.lifecycle"] = {
+      get_session = function(candidate)
+        assert.equals(tabpage, candidate)
+        return current_session
+      end,
+    }
+    package.loaded["codediff.core.git"] = {
+      get_file_content = function(revision, git_root, path, callback)
+        assert.equals("/repo", git_root)
+        assert.equals("file.txt", path)
+        callbacks[revision] = callback
+      end,
+    }
+    package.loaded["codediff.ui.auto_refresh"] = nil
+    auto_refresh = require("codediff.ui.auto_refresh")
+    original_trigger = auto_refresh.trigger
+    auto_refresh.trigger = function()
+      trigger_count = trigger_count + 1
+    end
+  end)
+
+  after_each(function()
+    auto_refresh.trigger = original_trigger
+    package.loaded["codediff.ui.auto_refresh"] = original_auto_refresh
+    package.loaded["codediff.core.git"] = original_git
+    package.loaded["codediff.ui.lifecycle"] = original_lifecycle
+    if vim.api.nvim_buf_is_valid(original_bufnr) then
+      vim.api.nvim_buf_delete(original_bufnr, { force = true })
+    end
+    if vim.api.nvim_buf_is_valid(modified_bufnr) then
+      vim.api.nvim_buf_delete(modified_bufnr, { force = true })
+    end
+  end)
+
+  it("completes only after every mutable target settles", function()
+    local completed = 0
+    auto_refresh.sync_mutable_buffers(tabpage, function()
+      completed = completed + 1
+    end)
+
+    assert.is_function(callbacks[":2"])
+    assert.is_function(callbacks[":3"])
+    assert.equals(0, completed)
+
+    callbacks[":2"](nil, { "new original" })
+    assert.is_true(vim.wait(1000, function()
+      return vim.api.nvim_buf_get_lines(original_bufnr, 0, -1, false)[1] == "new original"
+    end, 10))
+    assert.equals(0, completed)
+
+    callbacks[":3"](nil, { "new modified" })
+    assert.is_true(vim.wait(1000, function()
+      return completed == 1
+    end, 10))
+    assert.equals("new modified", vim.api.nvim_buf_get_lines(modified_bufnr, 0, -1, false)[1])
+    assert.equals(2, trigger_count)
+  end)
+
+  it("completes immediately when the session no longer exists", function()
+    current_session = nil
+    local completed = 0
+
+    auto_refresh.sync_mutable_buffers(tabpage, function()
+      completed = completed + 1
+    end)
+
+    assert.equals(1, completed)
+    assert.same({}, callbacks)
+  end)
+
+  it("completes immediately when neither side is mutable", function()
+    current_session.original_revision = "HEAD"
+    current_session.modified_revision = nil
+    local completed = 0
+
+    auto_refresh.sync_mutable_buffers(tabpage, function()
+      completed = completed + 1
+    end)
+
+    assert.equals(1, completed)
+    assert.same({}, callbacks)
+  end)
+
+  it("counts errors as settled", function()
+    current_session.modified_revision = nil
+    local completed = 0
+    auto_refresh.sync_mutable_buffers(tabpage, function()
+      completed = completed + 1
+    end)
+
+    callbacks[":2"]("git failed")
+
+    assert.is_true(vim.wait(1000, function()
+      return completed == 1
+    end, 10))
+    assert.equals("old original", vim.api.nvim_buf_get_lines(original_bufnr, 0, -1, false)[1])
+  end)
+
+  it("does not write after the owning session is replaced", function()
+    current_session.modified_revision = nil
+    local completed = 0
+    auto_refresh.sync_mutable_buffers(tabpage, function()
+      completed = completed + 1
+    end)
+    current_session = {}
+
+    callbacks[":2"](nil, { "stale" })
+
+    assert.is_true(vim.wait(1000, function()
+      return completed == 1
+    end, 10))
+    assert.equals("old original", vim.api.nvim_buf_get_lines(original_bufnr, 0, -1, false)[1])
+    assert.equals(0, trigger_count)
+  end)
+end)

--- a/tests/ui/explorer/explorer_refresh_spec.lua
+++ b/tests/ui/explorer/explorer_refresh_spec.lua
@@ -34,6 +34,8 @@ end
 describe("Explorer refresh and single-file stability", function()
   local temp_dir
   local original_cwd
+  local original_get_panel_view
+  local original_get_status_with_line_stats
 
   local function open(focus_file)
     local lifecycle = require("codediff.ui.lifecycle")
@@ -94,6 +96,14 @@ describe("Explorer refresh and single-file stability", function()
   end)
 
   after_each(function()
+    if original_get_panel_view then
+      require("codediff.ui.lifecycle").get_panel_view = original_get_panel_view
+      original_get_panel_view = nil
+    end
+    if original_get_status_with_line_stats then
+      require("codediff.core.git").get_status_with_line_stats = original_get_status_with_line_stats
+      original_get_status_with_line_stats = nil
+    end
     require("codediff.ui.lifecycle").cleanup_all()
     vim.cmd("tabnew")
     vim.cmd("tabonly")
@@ -102,6 +112,45 @@ describe("Explorer refresh and single-file stability", function()
     if temp_dir and vim.fn.isdirectory(temp_dir) == 1 then
       vim.fn.delete(temp_dir, "rf")
     end
+  end)
+
+  it("drops a refresh result when the explorer no longer owns the tab", function()
+    config.options.explorer.auto_refresh = false
+    local tabpage, explorer = open("file1.txt")
+    local lifecycle = require("codediff.ui.lifecycle")
+    local git = require("codediff.core.git")
+    local refresh = require("codediff.ui.explorer.refresh")
+    local status_before = vim.deepcopy(explorer.status_result)
+    local git_callback
+    local completed = 0
+
+    original_get_status_with_line_stats = git.get_status_with_line_stats
+    git.get_status_with_line_stats = function(_, callback)
+      git_callback = callback
+    end
+    refresh.refresh(explorer, function()
+      completed = completed + 1
+    end)
+    assert.is_function(git_callback)
+
+    original_get_panel_view = lifecycle.get_panel_view
+    lifecycle.get_panel_view = function(candidate)
+      assert.equals(tabpage, candidate)
+      return nil
+    end
+    git_callback(nil, {
+      unstaged = {
+        { path = "file1.txt", status = "M" },
+        { path = "new.txt", status = "??" },
+      },
+      staged = {},
+      conflicts = {},
+    })
+
+    assert.is_true(vim.wait(1000, function()
+      return completed == 1
+    end, 10))
+    assert.same(status_before, explorer.status_result)
   end)
 
   it("picks up an externally-created untracked file automatically", function()

--- a/tests/ui/explorer/native_watcher_spec.lua
+++ b/tests/ui/explorer/native_watcher_spec.lua
@@ -14,6 +14,7 @@ describe("explorer native watcher", function()
   local refresh_forces
   local refresh_count
   local sync_count
+  local sync_completions
 
   before_each(function()
     repository = vim.fn.tempname()
@@ -23,6 +24,7 @@ describe("explorer native watcher", function()
     refresh_forces = {}
     refresh_count = 0
     sync_count = 0
+    sync_completions = {}
     unsubscribed = false
 
     original_new_timer = uv.new_timer
@@ -58,8 +60,9 @@ describe("explorer native watcher", function()
 
     original_auto_refresh = package.loaded["codediff.ui.auto_refresh"]
     package.loaded["codediff.ui.auto_refresh"] = {
-      sync_mutable_buffers = function()
+      sync_mutable_buffers = function(_, done)
         sync_count = sync_count + 1
+        sync_completions[#sync_completions + 1] = done
       end,
     }
 
@@ -115,12 +118,16 @@ describe("explorer native watcher", function()
 
     refresh_completions[1]()
     assert.equals(1, sync_count)
+    assert.equals(1, refresh_count)
+
+    sync_completions[1]()
     assert.equals(2, refresh_count)
     assert.is_true(refresh_forces[2])
 
     refresh_completions[2]()
     assert.equals(2, sync_count)
     assert.equals(2, refresh_count)
+    sync_completions[2]()
   end)
 
   it("keeps status-equality shortcuts for fallback polling", function()
@@ -131,6 +138,22 @@ describe("explorer native watcher", function()
     end, 10))
     assert.is_false(refresh_forces[1])
     refresh_completions[1]()
+    sync_completions[1]()
+  end)
+
+  it("drops a trailing refresh when cleanup happens during mutable sync", function()
+    setup()
+    watcher_handlers.on_ready()
+    watcher_handlers.on_refresh()
+    refresh_completions[1]()
+
+    assert.equals(1, sync_count)
+    cleanup()
+    cleanup = nil
+    sync_completions[1]()
+
+    assert.equals(1, refresh_count)
+    assert.is_true(unsubscribed)
   end)
 
   it("returns to polling after a running watcher fails", function()

--- a/tests/ui/explorer/native_watcher_spec.lua
+++ b/tests/ui/explorer/native_watcher_spec.lua
@@ -67,8 +67,8 @@ describe("explorer native watcher", function()
     }
 
     refresh_module = require("codediff.ui.explorer.refresh")
-    original_refresh = refresh_module.refresh
-    refresh_module.refresh = function(_, done, force)
+    original_refresh = refresh_module._refresh_once
+    refresh_module._refresh_once = function(_, done, force)
       refresh_count = refresh_count + 1
       refresh_completions[#refresh_completions + 1] = done
       refresh_forces[#refresh_forces + 1] = force == true
@@ -80,7 +80,7 @@ describe("explorer native watcher", function()
       cleanup()
       cleanup = nil
     end
-    refresh_module.refresh = original_refresh
+    refresh_module._refresh_once = original_refresh
     package.loaded["codediff.core.watcher"] = original_watcher
     package.loaded["codediff.ui.auto_refresh"] = original_auto_refresh
     uv.new_timer = original_new_timer
@@ -110,8 +110,12 @@ describe("explorer native watcher", function()
     assert.equals(1, refresh_count)
     assert.is_true(refresh_forces[1])
 
+    local direct_completed = 0
     watcher_handlers.on_refresh()
     watcher_handlers.on_refresh()
+    refresh_module.refresh(explorer, function()
+      direct_completed = direct_completed + 1
+    end)
     watcher_handlers.on_refresh()
     assert.equals(1, refresh_count)
     assert.is_true(refresh_forces[1])
@@ -122,12 +126,14 @@ describe("explorer native watcher", function()
 
     sync_completions[1]()
     assert.equals(2, refresh_count)
+    assert.equals(0, direct_completed)
     assert.is_true(refresh_forces[2])
 
     refresh_completions[2]()
     assert.equals(2, sync_count)
     assert.equals(2, refresh_count)
     sync_completions[2]()
+    assert.equals(1, direct_completed)
   end)
 
   it("keeps status-equality shortcuts for fallback polling", function()


### PR DESCRIPTION
## Summary

Make every Explorer refresh source share one complete, lifecycle-safe refresh cycle. This hardens the native watcher and polling fallback against overlapping mutable-index reads, late callbacks after teardown, and external callers bypassing the queue.

## Changes

### Complete-cycle serialization

- Extend `sync_mutable_buffers(tabpage, done)` with an optional completion callback.
- Hold the Explorer refresh lock until all applicable `:0`–`:3` reads have settled.
- Treat missing sessions, absent targets, invalid buffers, and Git errors as completed work so the queue cannot remain stuck.
- Verify the session, side, buffer, revision, and path still match before writing an asynchronous result.

### Lifecycle ownership

- Re-check the authoritative lifecycle panel identity when a Git result returns.
- Drop results whose Explorer no longer owns the tab or whose window is no longer valid.
- Complete the request without rebuilding a stale tree, reselecting a file, or notifying an error after teardown.

### One public refresh queue

- Make `M.refresh()` the queue entry for watcher events, fallback ticks, manual refreshes, internal calls, and external integrations.
- Keep the existing Git/UI operation in the internal `_refresh_once()` function.
- Coalesce arbitrary overlap into one trailing cycle while OR-merging `force` intent.
- Deliver completion callbacks only after the trailing status and mutable synchronization finish.
- Install the passive queue even when automatic refresh is disabled, so manual/direct refreshes remain serialized without starting a watcher or timer.

## Motivation

Before this change, the watcher/timer path serialized `git status`, but mutable revision reads were fire-and-forget. A later index event could start another cycle while older `git show :0/:2/:3` calls were still running, allowing stale content to arrive last. Code that called the exported `M.refresh()` directly could also bypass the watcher queue entirely.

The concurrency analysis in #522 identified these failure modes. This PR implements the remaining correctness pieces on top of the native watcher architecture; it does not include #522's configurable polling API or restore polling as the primary refresh mechanism. Thanks @itaober for the original analysis and tests.

## Testing

- Added deterministic mutable synchronization coverage for zero, one, and two targets, errors, missing/replaced sessions, and stale-write rejection.
- Extended the native watcher queue contract to hold requests through mutable completion, drop pending work after cleanup, coalesce a direct `M.refresh()` call with watcher events, and delay its callback until the trailing cycle completes.
- Added a deterministic lifecycle ownership regression proving an old Git result cannot replace the current Explorer state.
- Confirmed the new tests fail against the previous implementation.
- Mutation check: dropping coalesced completion callbacks fails the queue contract.
- Related staged, hunk, refresh, and module-loading specs pass.
- Full suite passes with both one worker and four workers: 103 spec files.
- `stylua --check`, `git diff --check`, and the orphan-comment scan pass.
