### PR TITLE
ci: remove unused Node setup from native builds

### DIFF
--- a/.github/workflows/_platform-linux.yml
+++ b/.github/workflows/_platform-linux.yml
@@ -44,11 +44,6 @@ jobs:
           BUILD_VERSION: ${{ inputs.version }}
         run: printf '%s\n' "$BUILD_VERSION" > VERSION
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 'lts/*'
-
       - name: Install build tools
         run: |
           sudo apt-get update

--- a/.github/workflows/_platform-macos.yml
+++ b/.github/workflows/_platform-macos.yml
@@ -43,11 +43,6 @@ jobs:
           BUILD_VERSION: ${{ inputs.version }}
         run: printf '%s\n' "$BUILD_VERSION" > VERSION
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 'lts/*'
-
       - name: Setup Neovim
         uses: ./.github/actions/setup-neovim
         with:

--- a/.github/workflows/_platform-windows.yml
+++ b/.github/workflows/_platform-windows.yml
@@ -44,11 +44,6 @@ jobs:
           BUILD_VERSION: ${{ inputs.version }}
         run: Set-Content -Path VERSION -Value $env:BUILD_VERSION
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 'lts/*'
-
       - name: Setup Neovim
         uses: ./.github/actions/setup-neovim
         with:


### PR DESCRIPTION
## Summary

Remove unused Node.js setup from the native Linux, macOS, and Windows build workflows.

## Changes

- Remove `actions/setup-node` from `_platform-linux.yml`
- Remove `actions/setup-node` from `_platform-macos.yml`
- Remove `actions/setup-node` from `_platform-windows.yml`
- Keep Node.js setup in regression and Copilot workflows where Node programs are actually used
- Keep `next` PR validation unchanged

## Benefits

- Removes the last unused tooling left behind after deleting the manual Node version-bump script
- Reduces setup time and post-job cleanup in six native build cells
- Keeps the native workflows limited to the tools their commands consume

## Testing

- The release migration completed successfully across all eight target cells before this cleanup
- The three edited workflows contain no `node`, `npm`, or `npx` command
- YAML parsing passed
- `git diff --check` passed
