### PR TITLE
feat: review pull requests by number

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ https://github.com/user-attachments/assets/64c41f01-dffe-4318-bce4-16eec8de356e
 - **Side-by-side diff view** in a new tab with synchronized scrolling
 - **Inline (unified) diff view** — single-window layout with deleted lines as virtual overlays, with treesitter syntax highlighting
 - **Toggle layout** — switch between side-by-side and inline layout at runtime with `t`
-- **Git integration**: Compare between any git revision (HEAD, commits, branches, tags)
+- **Git integration**: Compare revisions or review a pull request by number without checking it out
 - **Same implementation as VSCode's diff engine**, providing identical visual highlighting for most scenarios
 - **Fast C-based diff computation** using FFI with **multi-core parallelization** (OpenMP)
 - **Async git operations** - non-blocking file retrieval from git
@@ -474,6 +474,44 @@ Show only changes introduced since branching from a base branch—exactly like a
 ```
 
 This uses `git merge-base` semantics (equivalent to `git diff main...HEAD`), showing only the changes introduced on your branch, not changes that happened on the base branch since you branched.
+
+#### Review a pull request
+
+Fetch and review a pull request without checking out its branch or changing the working tree:
+
+```vim
+:CodeDiff pr 512
+
+" Review a pull request in another local repository
+:CodeDiff --repo ~/code/codediff.nvim pr 512
+
+" Fetch from a target repository configured as upstream
+:CodeDiff pr 512 --remote upstream
+
+" Override the target branch when the PR targets a non-default branch
+:CodeDiff pr 512 --base release/3.x
+
+" Review only part of the PR
+:CodeDiff pr 512 -- lua/codediff
+```
+
+CodeDiff recognizes GitHub and Azure DevOps `refs/pull/` refs and GitLab `refs/merge-requests/` refs. It prefers the provider's synthetic merge ref, which identifies both sides of the review. If that ref is unavailable, CodeDiff fetches the PR head and compares it with the remote's default branch; use `--base` to override that fallback.
+
+Fetched commits are stored under `refs/codediff/pull-requests/`. Reopening the same PR updates its refs, and no local branch is created. The refs are retained so asynchronous file loading and later reviews can reuse them. Remove cached refs explicitly when they are no longer needed:
+
+```vim
+" Remove one PR from origin (use --remote for another remote)
+:CodeDiff pr clean 512
+:CodeDiff pr clean 512 --remote upstream
+
+" Remove every cached PR ref in this repository
+:CodeDiff pr clean --all
+
+" Limit --all to one remote
+:CodeDiff pr clean --all --remote upstream
+```
+
+Both cleanup forms support `--repo`/`-C`. Private repositories use the authentication already configured for the selected Git remote. No `gh`, `glab`, or `az` CLI is required.
 
 #### Scope to a subdirectory or path
 

--- a/doc/codediff.txt
+++ b/doc/codediff.txt
@@ -12,6 +12,7 @@ QUICK START                                           *codediff-quickstart*
 After installing the plugin and running |:CodeDiff|, you can:
 - Browse changed files (default explorer)
 - Compare the current file with a git revision
+- Review a pull request without checking it out
 - Compare two files or directories
 
 ==============================================================================
@@ -44,6 +45,35 @@ Target another repository (explorer and history modes):   *codediff-repo*
 <
 Operate on the repository containing the given path (its root or any
 subdirectory) instead of the current buffer/cwd. `-C` is a git-style alias.
+
+Review a pull request without checking it out:                 *codediff-pr*
+>vim
+  :CodeDiff pr 512
+  :CodeDiff --repo ~/code/other-repo pr 512
+  :CodeDiff pr 512 --remote upstream
+  :CodeDiff pr 512 --base release/3.x
+  :CodeDiff pr 512 -- lua/codediff
+<
+CodeDiff recognizes GitHub and Azure DevOps `refs/pull/` refs and GitLab
+`refs/merge-requests/` refs. It prefers a synthetic merge ref, which identifies
+both sides of the review. Otherwise it compares the PR head with the remote's
+default branch; use --base for a non-default target. `origin` is the default
+remote. Existing Git remote authentication is used; no provider CLI is needed.
+
+Fetched refs live under `refs/codediff/pull-requests/`, are overwritten when the
+same PR is reopened, and do not create a local branch or change the working
+tree. They are retained for asynchronous file loading and reuse.
+
+Delete cached refs explicitly:                              *codediff-pr-clean*
+>vim
+  :CodeDiff pr clean 512
+  :CodeDiff pr clean 512 --remote upstream
+  :CodeDiff pr clean --all
+  :CodeDiff pr clean --all --remote upstream
+<
+The first form deletes every cached ref for one PR on `origin` unless --remote
+is supplied. --all deletes every cached PR ref in the selected repository;
+--remote limits it to one remote. Both forms support --repo/-C.
 
 Scope to a subdirectory or path:                          *codediff-pathspec*
 >vim

--- a/doc/tags
+++ b/doc/tags
@@ -15,6 +15,8 @@ codediff-history-line-range	codediff.txt	/*codediff-history-line-range*
 codediff-layout	codediff.txt	/*codediff-layout*
 codediff-lua-api	codediff.txt	/*codediff-lua-api*
 codediff-moved-code	codediff.txt	/*codediff-moved-code*
+codediff-pr	codediff.txt	/*codediff-pr*
+codediff-pr-clean	codediff.txt	/*codediff-pr-clean*
 codediff-quickstart	codediff.txt	/*codediff-quickstart*
 codediff-see-also	codediff.txt	/*codediff-see-also*
 codediff-toggle-layout	codediff.txt	/*codediff-toggle-layout*

--- a/lua/codediff/commands/handlers/pull_request.lua
+++ b/lua/codediff/commands/handlers/pull_request.lua
@@ -1,0 +1,65 @@
+-- Review a pull request without checking out its branch.
+local M = {}
+
+local pull_request = require("codediff.core.pull_request")
+local parse = require("codediff.commands.parse")
+local explorer = require("codediff.commands.handlers.explorer")
+
+--- Fetch a pull request and open its merge-base diff.
+--- @param number number
+--- @param opts table { remote?: string, base?: string }
+--- @param global_opts table
+--- @param pathspec string[]|nil
+function M.run(number, opts, global_opts, pathspec)
+  vim.notify(string.format("Fetching pull request #%d from %s...", number, opts.remote or "origin"), vim.log.levels.INFO)
+  parse.resolve_working_root(global_opts, function(git_root)
+    pull_request.fetch(number, git_root, opts, function(err, revisions)
+      if parse.failed(err) then
+        return
+      end
+      vim.schedule(function()
+        local review_opts = vim.tbl_extend("force", global_opts, { repo = git_root })
+        explorer.run_merge_base(revisions.base_revision, revisions.head_revision, review_opts, pathspec)
+      end)
+    end)
+  end)
+end
+
+--- Delete cached refs for one pull request.
+--- @param number number
+--- @param opts table { remote?: string }
+--- @param global_opts table
+function M.clean(number, opts, global_opts)
+  parse.resolve_working_root(global_opts, function(git_root)
+    pull_request.clean(number, git_root, opts, function(err, deleted)
+      if parse.failed(err) then
+        return
+      end
+      vim.schedule(function()
+        vim.notify(
+          deleted == 0 and string.format("No cached refs for pull request #%d", number) or string.format("Removed %d cached ref(s) for pull request #%d", deleted, number),
+          vim.log.levels.INFO
+        )
+      end)
+    end)
+  end)
+end
+
+--- Delete all cached pull request refs, optionally for one remote.
+--- @param opts table { remote?: string }
+--- @param global_opts table
+function M.clean_all(opts, global_opts)
+  parse.resolve_working_root(global_opts, function(git_root)
+    pull_request.clean_all(git_root, opts, function(err, deleted)
+      if parse.failed(err) then
+        return
+      end
+      vim.schedule(function()
+        local scope = opts.remote and string.format(" for remote '%s'", opts.remote) or ""
+        vim.notify(deleted == 0 and "No cached pull request refs" .. scope or string.format("Removed %d cached pull request ref(s)%s", deleted, scope), vim.log.levels.INFO)
+      end)
+    end)
+  end)
+end
+
+return M

--- a/lua/codediff/commands/init.lua
+++ b/lua/codediff/commands/init.lua
@@ -3,7 +3,7 @@
 local M = {}
 
 -- Subcommands available for :CodeDiff
-M.SUBCOMMANDS = { "merge", "file", "dir", "history", "install" }
+M.SUBCOMMANDS = { "merge", "file", "dir", "history", "pr", "install" }
 
 local git = require("codediff.core.git")
 local ap = require("codediff.core.argparse")
@@ -15,6 +15,7 @@ local handlers = {
   file_diff = require("codediff.commands.handlers.file_diff"),
   dir_diff = require("codediff.commands.handlers.dir_diff"),
   history = require("codediff.commands.handlers.history"),
+  pull_request = require("codediff.commands.handlers.pull_request"),
   explorer = require("codediff.commands.handlers.explorer"),
   explorer_staged = require("codediff.commands.handlers.explorer_staged"),
   merge = require("codediff.commands.handlers.merge"),
@@ -138,6 +139,46 @@ local function build_app()
         handlers.explorer.run(a, nil, go, pathspec)
       end
     end)
+
+  local pr_command = ap.Command
+    .new("pr")
+    :about("Review a pull request without checking it out")
+    :arg(Arg.new("number"))
+    :arg(Arg.new("remote"):long("--remote"):global(true))
+    :arg(Arg.new("base"):long("--base"):completor(complete_revisions))
+    :trailing(Arg.new("pathspec"):completor(complete_files))
+    :handler(function(m)
+      local raw_number = m:get_one("number")
+      if not raw_number or not raw_number:match("^[1-9]%d*$") then
+        vim.notify("Usage: :CodeDiff pr <number> [--remote <name>] [--base <branch>]", vim.log.levels.ERROR)
+        return
+      end
+      local number = tonumber(raw_number)
+      local trailing = m:trailing()
+      handlers.pull_request.run(number, {
+        remote = m:get_one("remote") or "origin",
+        base = m:get_one("base"),
+      }, parse.to_global_opts(m), #trailing > 0 and trailing or nil)
+    end)
+
+  pr_command:subcommand(
+    ap.Command.new("clean"):about("Delete cached pull request refs"):arg(Arg.new("number")):arg(Arg.flag("all"):long("--all"):conflicts_with("number")):handler(function(m)
+      local raw_number = m:get_one("number")
+      if m:get_flag("all") then
+        handlers.pull_request.clean_all({ remote = m:get_one("remote") }, parse.to_global_opts(m))
+        return
+      end
+      if not raw_number or not raw_number:match("^[1-9]%d*$") then
+        vim.notify("Usage: :CodeDiff pr clean <number> [--remote <name>] | :CodeDiff pr clean --all", vim.log.levels.ERROR)
+        return
+      end
+      handlers.pull_request.clean(tonumber(raw_number), {
+        remote = m:get_one("remote") or "origin",
+      }, parse.to_global_opts(m))
+    end)
+  )
+
+  app:subcommand(pr_command)
 
   app:subcommand(ap.Command.new("file"):arg(Arg.new("a"):completor(complete_revisions)):arg(Arg.new("b"):completor(complete_files)):handler(function(m)
     local go = parse.to_global_opts(m)

--- a/lua/codediff/core/git.lua
+++ b/lua/codediff/core/git.lua
@@ -484,6 +484,118 @@ function M.resolve_revision(revision, git_root, callback)
   end)
 end
 
+--- List selected refs on a remote and resolve its default branch.
+--- @param remote string
+--- @param refs string[]
+--- @param git_root string
+--- @param callback fun(err: string|nil, result: table|nil)
+function M.list_remote_refs(remote, refs, git_root, callback)
+  local args = { "ls-remote", "--symref", remote, "HEAD" }
+  vim.list_extend(args, refs)
+  run_git_async(args, { cwd = git_root }, function(err, output)
+    if err then
+      callback(err, nil)
+      return
+    end
+
+    local result = { refs = {} }
+    for line in output:gmatch("[^\r\n]+") do
+      local symbolic = line:match("^ref:%s+(refs/heads/[^%s]+)%s+HEAD$")
+      if symbolic then
+        result.default_branch = symbolic
+      else
+        local hash, ref = line:match("^(%x+)%s+([^%s]+)$")
+        if hash and ref then
+          result.refs[ref] = hash
+        end
+      end
+    end
+    callback(nil, result)
+  end)
+end
+
+--- Force-fetch remote refs into explicit local refs.
+--- @param remote string
+--- @param refspecs table[] { source: string, destination: string }
+--- @param git_root string
+--- @param callback fun(err: string|nil)
+function M.fetch_remote_refs(remote, refspecs, git_root, callback)
+  local args = { "fetch", "--no-tags", remote }
+  for _, refspec in ipairs(refspecs) do
+    args[#args + 1] = "+" .. refspec.source .. ":" .. refspec.destination
+  end
+  run_git_async(args, { cwd = git_root }, function(err)
+    callback(err and vim.trim(err) or nil)
+  end)
+end
+
+--- Read the parent commit hashes of a revision.
+--- @param revision string
+--- @param git_root string
+--- @param callback fun(err: string|nil, parents: string[]|nil)
+function M.get_revision_parents(revision, git_root, callback)
+  run_git_async({ "rev-list", "--parents", "-n", "1", revision }, { cwd = git_root }, function(err, output)
+    if err then
+      callback(err, nil)
+      return
+    end
+    local commits = vim.split(vim.trim(output), "%s+", { trimempty = true })
+    table.remove(commits, 1)
+    callback(nil, commits)
+  end)
+end
+
+--- List local refs below a namespace prefix.
+--- @param prefix string
+--- @param git_root string
+--- @param callback fun(err: string|nil, refs: table[]|nil)
+function M.list_local_refs(prefix, git_root, callback)
+  run_git_async({ "for-each-ref", "--format=%(refname)%09%(objectname)", prefix }, { cwd = git_root }, function(err, output)
+    if err then
+      callback(err, nil)
+      return
+    end
+
+    local refs = {}
+    for line in output:gmatch("[^\r\n]+") do
+      local name, object = line:match("^([^\t]+)\t(%x+)$")
+      if name and object then
+        refs[#refs + 1] = { name = name, object = object }
+      end
+    end
+    callback(nil, refs)
+  end)
+end
+
+--- Delete local refs, verifying that none changed since they were listed.
+--- @param refs table[] { name: string, object: string }
+--- @param git_root string
+--- @param callback fun(err: string|nil, deleted: number)
+function M.delete_local_refs(refs, git_root, callback)
+  local index = 1
+  local deleted = 0
+
+  local function delete_next()
+    local ref = refs[index]
+    if not ref then
+      callback(nil, deleted)
+      return
+    end
+
+    run_git_async({ "update-ref", "-d", ref.name, ref.object }, { cwd = git_root }, function(err)
+      if err then
+        callback(string.format("Failed to delete ref '%s': %s", ref.name, vim.trim(err)), deleted)
+        return
+      end
+      deleted = deleted + 1
+      index = index + 1
+      delete_next()
+    end)
+  end
+
+  delete_next()
+end
+
 -- Get file content from a specific git revision (async, atomic)
 -- revision: e.g., "HEAD", "HEAD~1", commit hash, branch name, tag
 -- git_root: absolute path to git repository root

--- a/lua/codediff/core/pull_request.lua
+++ b/lua/codediff/core/pull_request.lua
@@ -1,0 +1,221 @@
+-- Pull request ref discovery and fetching across Git hosting providers.
+local M = {}
+
+local git = require("codediff.core.git")
+
+local local_ref_root = "refs/codediff/pull-requests"
+
+local ref_patterns = {
+  {
+    merge = "refs/pull/%d/merge", -- GitHub and Azure DevOps
+    head = "refs/pull/%d/head",
+  },
+  {
+    merge = "refs/merge-requests/%d/merge", -- GitLab
+    head = "refs/merge-requests/%d/head",
+  },
+}
+
+local function remote_key(remote)
+  return remote:gsub("[^%w._-]", "_")
+end
+
+local function local_remote_prefix(remote)
+  return string.format("%s/%s/", local_ref_root, remote_key(remote))
+end
+
+local function local_ref(remote, number, kind)
+  return string.format("%s%d/%s", local_remote_prefix(remote), number, kind)
+end
+
+local function base_ref(base)
+  if not base then
+    return nil
+  end
+  return base:match("^refs/heads/") and base or "refs/heads/" .. base
+end
+
+local function fetch_refs(ctx, refspecs, callback)
+  git.fetch_remote_refs(ctx.remote, refspecs, ctx.git_root, function(err)
+    if err then
+      callback(string.format("Failed to fetch pull request from remote '%s': %s", ctx.remote, err))
+      return
+    end
+    callback(nil)
+  end)
+end
+
+local function resolve_base(ctx, callback)
+  local source = base_ref(ctx.base) or ctx.remote_info.default_branch
+  if not source then
+    callback("Could not determine the pull request target branch; pass --base <branch>")
+    return
+  end
+
+  local destination = local_ref(ctx.remote, ctx.number, "base")
+  fetch_refs(ctx, { { source = source, destination = destination } }, function(err)
+    if err then
+      callback(err)
+      return
+    end
+    git.resolve_revision(destination, ctx.git_root, callback)
+  end)
+end
+
+local function finish_with_head(ctx, head_revision, callback)
+  resolve_base(ctx, function(err, base_revision)
+    if err then
+      callback(err, nil)
+      return
+    end
+    callback(nil, {
+      base_revision = base_revision,
+      head_revision = head_revision,
+      remote = ctx.remote,
+    })
+  end)
+end
+
+local function fetch_merge(ctx, source, callback)
+  local destination = local_ref(ctx.remote, ctx.number, "merge")
+  fetch_refs(ctx, { { source = source, destination = destination } }, function(err)
+    if err then
+      callback(err, nil)
+      return
+    end
+    git.get_revision_parents(destination, ctx.git_root, function(parent_err, parents)
+      if parent_err then
+        callback("Failed to inspect the pull request merge commit: " .. parent_err, nil)
+        return
+      end
+      if #parents < 2 then
+        callback("Pull request merge ref is not a two-parent merge commit", nil)
+        return
+      end
+      if ctx.base then
+        finish_with_head(ctx, parents[2], callback)
+      else
+        callback(nil, {
+          base_revision = parents[1],
+          head_revision = parents[2],
+          remote = ctx.remote,
+        })
+      end
+    end)
+  end)
+end
+
+local function fetch_head(ctx, source, callback)
+  local destination = local_ref(ctx.remote, ctx.number, "head")
+  fetch_refs(ctx, { { source = source, destination = destination } }, function(err)
+    if err then
+      callback(err, nil)
+      return
+    end
+    git.resolve_revision(destination, ctx.git_root, function(head_err, head_revision)
+      if head_err then
+        callback(head_err, nil)
+        return
+      end
+      finish_with_head(ctx, head_revision, callback)
+    end)
+  end)
+end
+
+local function first_available(refs, candidates)
+  for _, candidate in ipairs(candidates) do
+    if refs[candidate] then
+      return candidate
+    end
+  end
+end
+
+local function clean_prefix(prefix, git_root, callback)
+  git.list_local_refs(prefix, git_root, function(list_err, refs)
+    if list_err then
+      callback("Failed to list cached pull request refs: " .. vim.trim(list_err), nil)
+      return
+    end
+    git.delete_local_refs(refs, git_root, callback)
+  end)
+end
+
+--- Delete every cached ref for one pull request on a remote.
+--- @param number number
+--- @param git_root string Repository root
+--- @param opts table? { remote?: string }
+--- @param callback fun(err: string|nil, deleted: number|nil)
+function M.clean(number, git_root, opts, callback)
+  if type(number) ~= "number" or number < 1 or number % 1 ~= 0 then
+    callback("Pull request number must be a positive integer", nil)
+    return
+  end
+  opts = opts or {}
+  local prefix = string.format("%s%d/", local_remote_prefix(opts.remote or "origin"), number)
+  clean_prefix(prefix, git_root, callback)
+end
+
+--- Delete cached pull request refs, optionally scoped to one remote.
+--- @param git_root string Repository root
+--- @param opts table? { remote?: string }
+--- @param callback fun(err: string|nil, deleted: number|nil)
+function M.clean_all(git_root, opts, callback)
+  opts = opts or {}
+  local prefix = opts.remote and local_remote_prefix(opts.remote) or local_ref_root .. "/"
+  clean_prefix(prefix, git_root, callback)
+end
+
+--- Fetch a pull request without checking it out and return its review range.
+--- @param number number Pull request or merge request number
+--- @param git_root string Repository root
+--- @param opts table? { remote?: string, base?: string }
+--- @param callback fun(err: string|nil, result: table|nil)
+function M.fetch(number, git_root, opts, callback)
+  opts = opts or {}
+  local ctx = {
+    number = number,
+    git_root = git_root,
+    remote = opts.remote or "origin",
+    base = opts.base,
+  }
+  local requested_refs = {}
+  local merge_refs = {}
+  local head_refs = {}
+
+  for _, pattern in ipairs(ref_patterns) do
+    local merge_ref = pattern.merge:format(number)
+    local head_ref = pattern.head:format(number)
+    merge_refs[#merge_refs + 1] = merge_ref
+    head_refs[#head_refs + 1] = head_ref
+    requested_refs[#requested_refs + 1] = merge_ref
+    requested_refs[#requested_refs + 1] = head_ref
+  end
+  local requested_base = base_ref(opts.base)
+  if requested_base then
+    requested_refs[#requested_refs + 1] = requested_base
+  end
+
+  git.list_remote_refs(ctx.remote, requested_refs, git_root, function(err, remote_info)
+    if err then
+      callback(string.format("Failed to query remote '%s': %s", ctx.remote, vim.trim(err)), nil)
+      return
+    end
+    ctx.remote_info = remote_info
+
+    local merge_ref = first_available(remote_info.refs, merge_refs)
+    if merge_ref then
+      fetch_merge(ctx, merge_ref, callback)
+      return
+    end
+
+    local head_ref = first_available(remote_info.refs, head_refs)
+    if head_ref then
+      fetch_head(ctx, head_ref, callback)
+      return
+    end
+
+    callback(string.format("Pull request #%d was not found on remote '%s'", number, ctx.remote), nil)
+  end)
+end
+
+return M

--- a/tests/command_e2e_spec.lua
+++ b/tests/command_e2e_spec.lua
@@ -420,11 +420,17 @@ describe("Command E2E (real dispatch + render)", function()
   it("completion offers subcommands and git refs", function()
     vim.cmd("lcd " .. repo.dir)
     local cands = commands.complete("", "CodeDiff ")
-    for _, name in ipairs({ "file", "dir", "history", "merge", "install" }) do
+    for _, name in ipairs({ "file", "dir", "history", "pr", "merge", "install" }) do
       assert.is_true(vim.tbl_contains(cands, name), "offers subcommand " .. name)
     end
     assert.is_true(vim.tbl_contains(cands, "HEAD"), "offers HEAD ref")
     assert.is_true(vim.tbl_contains(commands.complete("--r", "CodeDiff --r"), "--repo"), "offers --repo flag")
+    assert.is_true(vim.tbl_contains(commands.complete("", "CodeDiff pr "), "clean"), "offers PR cleanup")
+    assert.is_true(vim.tbl_contains(commands.complete("--r", "CodeDiff pr 12 --r"), "--remote"), "offers PR remote flag")
+    assert.is_true(vim.tbl_contains(commands.complete("--b", "CodeDiff pr 12 --b"), "--base"), "offers PR base flag")
+    assert.is_true(vim.tbl_contains(commands.complete("--a", "CodeDiff pr clean --a"), "--all"), "offers cleanup all flag")
+    assert.is_false(vim.tbl_contains(commands.complete("-a", "CodeDiff pr clean -a"), "-a"), "does not offer a short cleanup alias")
+    assert.is_false(vim.tbl_contains(commands.complete("", "CodeDiff pr 12 -- "), "HEAD"), "PR path scope excludes revisions")
   end)
 
   it("completion after -- offers file paths, not subcommands or refs (#74)", function()

--- a/tests/completion_spec.lua
+++ b/tests/completion_spec.lua
@@ -1,7 +1,7 @@
 -- Test: Command completion
 -- Validates :CodeDiff command completion with dynamic git refs
 
-local git = require('codediff.core.git')
+local git = require("codediff.core.git")
 local commands = require("codediff.commands")
 
 describe("Command Completion", function()
@@ -103,6 +103,7 @@ describe("Command Completion", function()
 
     it("Contains expected subcommands", function()
       assert.is_true(vim.tbl_contains(commands.SUBCOMMANDS, "file"), "Should include 'file'")
+      assert.is_true(vim.tbl_contains(commands.SUBCOMMANDS, "pr"), "Should include 'pr'")
       assert.is_true(vim.tbl_contains(commands.SUBCOMMANDS, "install"), "Should include 'install'")
     end)
   end)

--- a/tests/core/pull_request_spec.lua
+++ b/tests/core/pull_request_spec.lua
@@ -1,0 +1,290 @@
+local pull_request = require("codediff.core.pull_request")
+local h = dofile("tests/helpers.lua")
+
+local function run(cwd, args)
+  local command = { "git", "-C", cwd }
+  vim.list_extend(command, args)
+  local result = vim.system(command, { text = true }):wait()
+  assert.equals(0, result.code, result.stderr or result.stdout)
+  return vim.trim(result.stdout or "")
+end
+
+local function fetch_pull_request(repo, number, opts)
+  local done = false
+  local result_error
+  local result
+  pull_request.fetch(number, repo.dir, opts or {}, function(err, revisions)
+    result_error = err
+    result = revisions
+    done = true
+  end)
+  assert.is_true(
+    vim.wait(5000, function()
+      return done
+    end, 10),
+    "pull request fetch did not finish"
+  )
+  return result_error, result
+end
+
+local function list_cached_refs(repo, prefix)
+  local output = run(repo.dir, { "for-each-ref", "--format=%(refname)", prefix or "refs/codediff/pull-requests/" })
+  return vim.split(output, "\n", { trimempty = true })
+end
+
+local function wait_for_cleanup(start)
+  local done = false
+  local result_error
+  local deleted
+  start(function(err, count)
+    result_error = err
+    deleted = count
+    done = true
+  end)
+  assert.is_true(
+    vim.wait(5000, function()
+      return done
+    end, 10),
+    "pull request cleanup did not finish"
+  )
+  return result_error, deleted
+end
+
+describe("pull request fetching", function()
+  local repo
+  local remote
+  local base_revision
+  local head_revision
+  local merge_revision
+  local review_base
+
+  before_each(function()
+    repo = h.create_temp_git_repo()
+    remote = h.create_temp_dir()
+    run(remote, { "init", "--bare" })
+    run(remote, { "symbolic-ref", "HEAD", "refs/heads/main" })
+
+    repo.write_file("review.txt", { "base" })
+    repo.git("add review.txt")
+    repo.git("commit -m base")
+
+    repo.git("checkout -b feature")
+    repo.write_file("review.txt", { "feature" })
+    repo.write_file("ignored.txt", { "ignored" })
+    repo.git("add review.txt ignored.txt")
+    repo.git("commit -m feature")
+    head_revision = run(repo.dir, { "rev-parse", "HEAD" })
+
+    repo.git("checkout main")
+    repo.write_file("main.txt", { "main" })
+    repo.git("add main.txt")
+    repo.git("commit -m main")
+    base_revision = run(repo.dir, { "rev-parse", "HEAD" })
+
+    run(repo.dir, { "remote", "add", "origin", remote })
+    run(repo.dir, { "branch", "release", base_revision })
+    run(repo.dir, { "push", "origin", "main", "release" })
+    run(repo.dir, { "checkout", "-b", "synthetic-merge" })
+    run(repo.dir, { "merge", "--no-ff", "feature", "-m", "pull request merge" })
+    merge_revision = run(repo.dir, { "rev-parse", "HEAD" })
+    run(repo.dir, { "push", "origin", head_revision .. ":refs/pull/7/head" })
+    run(repo.dir, { "push", "origin", merge_revision .. ":refs/pull/7/merge" })
+    run(repo.dir, { "push", "origin", head_revision .. ":refs/merge-requests/8/head" })
+    run(repo.dir, { "push", "origin", head_revision .. ":refs/pull/9/head" })
+    run(repo.dir, { "push", "origin", merge_revision .. ":refs/merge-requests/10/merge" })
+    review_base = run(repo.dir, { "merge-base", base_revision, head_revision })
+    repo.git("checkout main")
+  end)
+
+  after_each(function()
+    h.close_extra_tabs()
+    if repo then
+      repo.cleanup()
+    end
+    if remote then
+      vim.fn.delete(remote, "rf")
+    end
+  end)
+
+  it("uses GitHub and Azure DevOps merge refs", function()
+    local err, revisions = fetch_pull_request(repo, 7)
+
+    assert.is_nil(err)
+    assert.equals(base_revision, revisions.base_revision)
+    assert.equals(head_revision, revisions.head_revision)
+    assert.equals("origin", revisions.remote)
+    assert.equals(merge_revision, run(repo.dir, { "rev-parse", "refs/codediff/pull-requests/origin/7/merge" }))
+  end)
+
+  it("uses a GitLab merge ref", function()
+    local err, revisions = fetch_pull_request(repo, 10)
+
+    assert.is_nil(err)
+    assert.equals(base_revision, revisions.base_revision)
+    assert.equals(head_revision, revisions.head_revision)
+  end)
+
+  it("falls back to a GitLab head ref and the remote default branch", function()
+    local err, revisions = fetch_pull_request(repo, 8)
+
+    assert.is_nil(err)
+    assert.equals(base_revision, revisions.base_revision)
+    assert.equals(head_revision, revisions.head_revision)
+    assert.equals(head_revision, run(repo.dir, { "rev-parse", "refs/codediff/pull-requests/origin/8/head" }))
+  end)
+
+  it("updates its cached ref when the pull request head moves", function()
+    local first_err, first = fetch_pull_request(repo, 8)
+    assert.is_nil(first_err)
+    assert.equals(head_revision, first.head_revision)
+
+    run(repo.dir, { "checkout", "-b", "rewritten", head_revision .. "^" })
+    repo.write_file("review.txt", { "rewritten" })
+    repo.git("add review.txt")
+    repo.git("commit -m update")
+    local updated_head = run(repo.dir, { "rev-parse", "HEAD" })
+    run(repo.dir, { "push", "--force", "origin", updated_head .. ":refs/merge-requests/8/head" })
+
+    local second_err, second = fetch_pull_request(repo, 8)
+    assert.is_nil(second_err)
+    assert.equals(updated_head, second.head_revision)
+    assert.equals(updated_head, run(repo.dir, { "rev-parse", "refs/codediff/pull-requests/origin/8/head" }))
+  end)
+
+  it("uses an explicit target branch when no merge ref exists", function()
+    local err, revisions = fetch_pull_request(repo, 9, { base = "release" })
+
+    assert.is_nil(err)
+    assert.equals(base_revision, revisions.base_revision)
+    assert.equals(head_revision, revisions.head_revision)
+  end)
+
+  it("cleans one pull request without touching another remote or number", function()
+    run(repo.dir, { "update-ref", "refs/codediff/pull-requests/origin/7/merge", merge_revision })
+    run(repo.dir, { "update-ref", "refs/codediff/pull-requests/origin/70/head", head_revision })
+    run(repo.dir, { "update-ref", "refs/codediff/pull-requests/upstream/7/head", head_revision })
+
+    local err, deleted = wait_for_cleanup(function(callback)
+      pull_request.clean(7, repo.dir, { remote = "origin" }, callback)
+    end)
+
+    assert.is_nil(err)
+    assert.equals(1, deleted)
+    assert.equals(0, #list_cached_refs(repo, "refs/codediff/pull-requests/origin/7/"))
+    assert.equals(1, #list_cached_refs(repo, "refs/codediff/pull-requests/origin/70/"))
+    assert.equals(1, #list_cached_refs(repo, "refs/codediff/pull-requests/upstream/7/"))
+  end)
+
+  it("cleans all refs with optional remote scoping", function()
+    run(repo.dir, { "update-ref", "refs/codediff/pull-requests/origin/7/merge", merge_revision })
+    run(repo.dir, { "update-ref", "refs/codediff/pull-requests/origin/8/head", head_revision })
+    run(repo.dir, { "update-ref", "refs/codediff/pull-requests/origin/8/base", base_revision })
+    run(repo.dir, { "update-ref", "refs/codediff/pull-requests/upstream/9/head", head_revision })
+    run(repo.dir, { "update-ref", "refs/codediff/other", head_revision })
+
+    local origin_err, origin_deleted = wait_for_cleanup(function(callback)
+      pull_request.clean_all(repo.dir, { remote = "origin" }, callback)
+    end)
+
+    assert.is_nil(origin_err)
+    assert.equals(3, origin_deleted)
+    assert.equals(1, #list_cached_refs(repo))
+
+    local all_err, all_deleted = wait_for_cleanup(function(callback)
+      pull_request.clean_all(repo.dir, {}, callback)
+    end)
+
+    assert.is_nil(all_err)
+    assert.equals(1, all_deleted)
+    assert.equals(0, #list_cached_refs(repo))
+    assert.equals(head_revision, run(repo.dir, { "rev-parse", "refs/codediff/other" }))
+  end)
+
+  it("opens the review through the pr subcommand", function()
+    run(repo.dir, { "remote", "rename", "origin", "upstream" })
+    vim.cmd("CodeDiff --repo " .. vim.fn.fnameescape(repo.dir) .. " pr 7 --remote upstream --base release -- review.txt")
+
+    local session
+    assert.is_true(
+      vim.wait(10000, function()
+        local lifecycle = require("codediff.ui.lifecycle")
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+          local candidate = lifecycle.get_session(tabpage)
+          if candidate and candidate.panel and candidate.panel.name == "explorer" then
+            session = candidate
+            return candidate.original_revision == review_base and candidate.modified_revision == head_revision
+          end
+        end
+        return false
+      end, 20),
+      "pull request review did not open"
+    )
+    assert.is_not_nil(session)
+    local files = require("codediff.ui.explorer.refresh").get_all_files(session.panel.view.tree)
+    assert.equals(1, #files)
+    assert.equals("review.txt", files[1].data.path)
+    assert.equals("main", run(repo.dir, { "branch", "--show-current" }))
+    assert.equals("", run(repo.dir, { "status", "--porcelain" }))
+  end)
+
+  it("cleans cached refs through the pr clean commands", function()
+    run(repo.dir, { "update-ref", "refs/codediff/pull-requests/origin/7/merge", merge_revision })
+    run(repo.dir, { "update-ref", "refs/codediff/pull-requests/origin/8/head", head_revision })
+
+    local messages = {}
+    local original_notify = vim.notify
+    vim.notify = function(text)
+      messages[#messages + 1] = tostring(text)
+    end
+
+    vim.cmd("CodeDiff --repo " .. vim.fn.fnameescape(repo.dir) .. " pr clean 7")
+    local cleaned_one = vim.wait(5000, function()
+      return #messages >= 1
+    end, 10)
+    assert.is_true(cleaned_one, "single-PR cleanup did not finish")
+    assert.equals(0, #list_cached_refs(repo, "refs/codediff/pull-requests/origin/7/"))
+    assert.equals(1, #list_cached_refs(repo, "refs/codediff/pull-requests/origin/8/"))
+
+    vim.cmd("CodeDiff --repo " .. vim.fn.fnameescape(repo.dir) .. " pr clean --all")
+    local cleaned_all = vim.wait(5000, function()
+      return #messages >= 2
+    end, 10)
+    vim.notify = original_notify
+
+    assert.is_true(cleaned_all, "all-PR cleanup did not finish")
+    assert.equals(0, #list_cached_refs(repo))
+    assert.matches("Removed 1 cached ref", messages[1])
+    assert.matches("Removed 1 cached pull request ref", messages[2])
+  end)
+
+  it("rejects an invalid pull request number", function()
+    local message
+    local original_notify = vim.notify
+    vim.notify = function(text)
+      message = tostring(text)
+    end
+    vim.cmd("CodeDiff pr nope")
+    vim.notify = original_notify
+
+    assert.matches("Usage: :CodeDiff pr", message)
+  end)
+
+  it("rejects clean without a pull request number or --all", function()
+    local message
+    local original_notify = vim.notify
+    vim.notify = function(text)
+      message = tostring(text)
+    end
+    vim.cmd("CodeDiff pr clean")
+    vim.notify = original_notify
+
+    assert.matches("Usage: :CodeDiff pr clean", message)
+  end)
+
+  it("reports a missing pull request", function()
+    local err, revisions = fetch_pull_request(repo, 404)
+
+    assert.is_nil(revisions)
+    assert.matches("Pull request #404 was not found", err)
+  end)
+end)


### PR DESCRIPTION
## Summary

Add first-class pull request review by number without checking out a branch or changing the working tree.

```vim
:CodeDiff pr 512
:CodeDiff pr 512 --remote upstream
:CodeDiff pr 512 --base release/3.x
:CodeDiff pr 512 -- lua/codediff
```

## Changes

- discover and fetch provider pull request refs directly through Git
  - GitHub and Azure DevOps: `refs/pull/<number>/{merge,head}`
  - GitLab: `refs/merge-requests/<number>/{merge,head}`
- prefer the provider synthetic merge commit so its parents identify the review base and head
- fall back to the PR head plus the remote default branch, with `--base` for non-default targets
- support `--remote`, the existing `--repo`/`-C` override, and Git pathspecs
- keep fetched commits under `refs/codediff/pull-requests/` and force-update them after PR force-pushes
- add explicit cache cleanup commands:
  - `:CodeDiff pr clean <number>`
  - `:CodeDiff pr clean --all`
  - both support repository selection; cleanup can be scoped with `--remote`
- separate atomic Git operations from provider-specific pull request orchestration
- document the command, ref lifecycle, supported providers, and cleanup behavior

## Benefits

- review a PR from its number with the existing merge-base Explorer
- no checkout, local branch, worktree mutation, provider CLI, or API token required
- works with existing Git remote authentication, including private repositories
- supports fork workflows by selecting the target repository remote
- cached refs remain safe for lazy/asynchronous file loading while remaining explicitly removable

## Testing

- `CODEDIFF_TEST_JOBS=1 ./tests/run_tests.sh` — 108 spec files passed
- pull request integration suite — 12 tests passed against local bare remotes
- command E2E suite — 24 tests passed
- verified GitHub/Azure DevOps and GitLab ref layouts, merge and head fallback paths, explicit base selection, non-origin remotes, force-push updates, pathspecs, invalid/missing PRs, and branch/worktree invariants
- verified targeted cleanup does not remove another PR, remote, or unrelated `refs/codediff/*` namespace
- mutation-checked provider selection, force-update behavior, merge-base dispatch, targeted cleanup, and all-ref cleanup
- manually opened GitHub PR #512 end-to-end without checkout
