### PR TITLE
docs: collapse full configuration reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ Both methods automatically place the library in the plugin root directory.
 
 ## Configuration
 
-**With custom configuration:**
+<details>
+<summary><strong>Full configuration reference</strong></summary>
+
 ```lua
 {
   "esmuellert/codediff.nvim",
@@ -313,6 +315,8 @@ Both methods automatically place the library in the plugin root directory.
   },
 }
 ```
+
+</details>
 
 ### Keymaps
 


### PR DESCRIPTION
## Summary

Collapse the complete README configuration reference by default while keeping the focused configuration guidance visible.

## Changes

- Wrap the full `opts` example in a native GitHub `<details>` block.
- Keep the complete configuration available with one click.
- Leave the Keymaps, Explorer line statistics, Explorer line formatters, and Gutter signs sections expanded.

## Benefits

- Reduces the rendered README by roughly five viewport heights.
- Preserves the README as a self-contained reference without splitting content across documents.
- Makes Installation and Usage easier to reach while retaining every documented option.

## Verification

- `git diff --check`
- Confirmed balanced Markdown code fences and `<details>` tags.
