### PR TITLE
fix(navigation): handle EOF deletion hunks

### DIFF
--- a/lua/codediff/ui/view/cursor.lua
+++ b/lua/codediff/ui/view/cursor.lua
@@ -1,0 +1,21 @@
+local api = vim.api
+
+local M = {}
+
+function M.clamp_line(bufnr, line)
+  local line_count = api.nvim_buf_line_count(bufnr)
+  return math.max(1, math.min(line, line_count))
+end
+
+function M.clamp_window_line(win, line)
+  return M.clamp_line(api.nvim_win_get_buf(win), line)
+end
+
+function M.clamp_cursor(win, position)
+  return {
+    M.clamp_window_line(win, position[1]),
+    position[2] or 0,
+  }
+end
+
+return M

--- a/lua/codediff/ui/view/inline_view/render.lua
+++ b/lua/codediff/ui/view/inline_view/render.lua
@@ -6,12 +6,7 @@ local config = require("codediff.config")
 local diff_module = require("codediff.core.diff")
 local inline = require("codediff.ui.inline")
 local semantic = require("codediff.ui.semantic_tokens")
-
-local function clamp_line(win, line)
-  local bufnr = vim.api.nvim_win_get_buf(win)
-  local line_count = vim.api.nvim_buf_line_count(bufnr)
-  return math.max(1, math.min(line, line_count))
-end
+local cursor_util = require("codediff.ui.view.cursor")
 
 function M.compute_and_render_inline(modified_buf, original_buf, original_lines, modified_lines, original_is_virtual, modified_is_virtual, modified_win, auto_scroll_to_first_hunk)
   local diff_options = {
@@ -51,7 +46,7 @@ function M.compute_and_render_inline(modified_buf, original_buf, original_lines,
       end
 
       local target_line = landing == "last" and lines_diff.changes[#lines_diff.changes].modified.start_line or lines_diff.changes[1].modified.start_line
-      target_line = clamp_line(modified_win, target_line)
+      target_line = cursor_util.clamp_window_line(modified_win, target_line)
       pcall(vim.api.nvim_win_set_cursor, modified_win, { target_line, 0 })
       vim.api.nvim_set_current_win(modified_win)
       vim.cmd("normal! zz")

--- a/lua/codediff/ui/view/inline_view/render.lua
+++ b/lua/codediff/ui/view/inline_view/render.lua
@@ -7,6 +7,12 @@ local diff_module = require("codediff.core.diff")
 local inline = require("codediff.ui.inline")
 local semantic = require("codediff.ui.semantic_tokens")
 
+local function clamp_line(win, line)
+  local bufnr = vim.api.nvim_win_get_buf(win)
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  return math.max(1, math.min(line, line_count))
+end
+
 function M.compute_and_render_inline(modified_buf, original_buf, original_lines, modified_lines, original_is_virtual, modified_is_virtual, modified_win, auto_scroll_to_first_hunk)
   local diff_options = {
     max_computation_time_ms = config.options.diff.max_computation_time_ms,
@@ -45,6 +51,7 @@ function M.compute_and_render_inline(modified_buf, original_buf, original_lines,
       end
 
       local target_line = landing == "last" and lines_diff.changes[#lines_diff.changes].modified.start_line or lines_diff.changes[1].modified.start_line
+      target_line = clamp_line(modified_win, target_line)
       pcall(vim.api.nvim_win_set_cursor, modified_win, { target_line, 0 })
       vim.api.nvim_set_current_win(modified_win)
       vim.cmd("normal! zz")

--- a/lua/codediff/ui/view/navigation.lua
+++ b/lua/codediff/ui/view/navigation.lua
@@ -4,6 +4,11 @@ local M = {}
 local lifecycle = require("codediff.ui.lifecycle")
 local config = require("codediff.config")
 
+local function hunk_start_line(range, bufnr)
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  return math.max(1, math.min(range.start_line, line_count))
+end
+
 -- Hop to the next/previous file in the explorer's list.
 --
 -- The cursor will land on the first or last hunk of the new file once the
@@ -80,7 +85,7 @@ function M.next_hunk()
 
   -- Find next hunk after current line
   for i, mapping in ipairs(diff_result.changes) do
-    local target_line = is_original and mapping.original.start_line or mapping.modified.start_line
+    local target_line = hunk_start_line(is_original and mapping.original or mapping.modified, vim.api.nvim_get_current_buf())
     if target_line > current_line then
       pcall(vim.api.nvim_win_set_cursor, 0, { target_line, 0 })
       vim.cmd("normal! zz")
@@ -98,7 +103,7 @@ function M.next_hunk()
   -- Wrap around to first hunk (if cycling enabled)
   if config.options.diff.cycle_next_hunk then
     local first_hunk = diff_result.changes[1]
-    local target_line = is_original and first_hunk.original.start_line or first_hunk.modified.start_line
+    local target_line = hunk_start_line(is_original and first_hunk.original or first_hunk.modified, vim.api.nvim_get_current_buf())
     pcall(vim.api.nvim_win_set_cursor, 0, { target_line, 0 })
     vim.cmd("normal! zz")
     vim.api.nvim_echo({ { string.format("Hunk 1 of %d", #diff_result.changes), "None" } }, false, {})
@@ -155,7 +160,7 @@ function M.prev_hunk()
   -- Find previous hunk before current line (search backwards)
   for i = #diff_result.changes, 1, -1 do
     local mapping = diff_result.changes[i]
-    local target_line = is_original and mapping.original.start_line or mapping.modified.start_line
+    local target_line = hunk_start_line(is_original and mapping.original or mapping.modified, vim.api.nvim_get_current_buf())
     if target_line < current_line then
       pcall(vim.api.nvim_win_set_cursor, 0, { target_line, 0 })
       vim.cmd("normal! zz")
@@ -172,7 +177,7 @@ function M.prev_hunk()
   -- Wrap around to last hunk (if cycling enabled)
   if config.options.diff.cycle_next_hunk then
     local last_hunk = diff_result.changes[#diff_result.changes]
-    local target_line = is_original and last_hunk.original.start_line or last_hunk.modified.start_line
+    local target_line = hunk_start_line(is_original and last_hunk.original or last_hunk.modified, vim.api.nvim_get_current_buf())
     pcall(vim.api.nvim_win_set_cursor, 0, { target_line, 0 })
     vim.cmd("normal! zz")
     vim.api.nvim_echo({ { string.format("Hunk %d of %d", #diff_result.changes, #diff_result.changes), "None" } }, false, {})

--- a/lua/codediff/ui/view/navigation.lua
+++ b/lua/codediff/ui/view/navigation.lua
@@ -3,11 +3,7 @@ local M = {}
 
 local lifecycle = require("codediff.ui.lifecycle")
 local config = require("codediff.config")
-
-local function hunk_start_line(range, bufnr)
-  local line_count = vim.api.nvim_buf_line_count(bufnr)
-  return math.max(1, math.min(range.start_line, line_count))
-end
+local cursor_util = require("codediff.ui.view.cursor")
 
 -- Hop to the next/previous file in the explorer's list.
 --
@@ -85,7 +81,7 @@ function M.next_hunk()
 
   -- Find next hunk after current line
   for i, mapping in ipairs(diff_result.changes) do
-    local target_line = hunk_start_line(is_original and mapping.original or mapping.modified, vim.api.nvim_get_current_buf())
+    local target_line = cursor_util.clamp_line(vim.api.nvim_get_current_buf(), (is_original and mapping.original or mapping.modified).start_line)
     if target_line > current_line then
       pcall(vim.api.nvim_win_set_cursor, 0, { target_line, 0 })
       vim.cmd("normal! zz")
@@ -103,7 +99,7 @@ function M.next_hunk()
   -- Wrap around to first hunk (if cycling enabled)
   if config.options.diff.cycle_next_hunk then
     local first_hunk = diff_result.changes[1]
-    local target_line = hunk_start_line(is_original and first_hunk.original or first_hunk.modified, vim.api.nvim_get_current_buf())
+    local target_line = cursor_util.clamp_line(vim.api.nvim_get_current_buf(), (is_original and first_hunk.original or first_hunk.modified).start_line)
     pcall(vim.api.nvim_win_set_cursor, 0, { target_line, 0 })
     vim.cmd("normal! zz")
     vim.api.nvim_echo({ { string.format("Hunk 1 of %d", #diff_result.changes), "None" } }, false, {})
@@ -160,7 +156,7 @@ function M.prev_hunk()
   -- Find previous hunk before current line (search backwards)
   for i = #diff_result.changes, 1, -1 do
     local mapping = diff_result.changes[i]
-    local target_line = hunk_start_line(is_original and mapping.original or mapping.modified, vim.api.nvim_get_current_buf())
+    local target_line = cursor_util.clamp_line(vim.api.nvim_get_current_buf(), (is_original and mapping.original or mapping.modified).start_line)
     if target_line < current_line then
       pcall(vim.api.nvim_win_set_cursor, 0, { target_line, 0 })
       vim.cmd("normal! zz")
@@ -177,7 +173,7 @@ function M.prev_hunk()
   -- Wrap around to last hunk (if cycling enabled)
   if config.options.diff.cycle_next_hunk then
     local last_hunk = diff_result.changes[#diff_result.changes]
-    local target_line = hunk_start_line(is_original and last_hunk.original or last_hunk.modified, vim.api.nvim_get_current_buf())
+    local target_line = cursor_util.clamp_line(vim.api.nvim_get_current_buf(), (is_original and last_hunk.original or last_hunk.modified).start_line)
     pcall(vim.api.nvim_win_set_cursor, 0, { target_line, 0 })
     vim.cmd("normal! zz")
     vim.api.nvim_echo({ { string.format("Hunk %d of %d", #diff_result.changes, #diff_result.changes), "None" } }, false, {})

--- a/lua/codediff/ui/view/render.lua
+++ b/lua/codediff/ui/view/render.lua
@@ -6,6 +6,12 @@ local semantic = require("codediff.ui.semantic_tokens")
 local config = require("codediff.config")
 local diff_module = require("codediff.core.diff")
 
+local function clamp_cursor(win, position)
+  local bufnr = vim.api.nvim_win_get_buf(win)
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  return { math.max(1, math.min(position[1], line_count)), position[2] or 0 }
+end
+
 --- Establish scroll synchronization between the two diff windows.
 --- Positions each pane's cursor on its own hunk line, then binds them with the
 --- structural virtual-row scroll-sync (see codediff.scrollsync) and aligns the
@@ -24,10 +30,10 @@ function M.establish_scrollbind(orig_win, mod_win, orig_buf, mod_buf, lines_diff
 
   -- Place cursors on their respective hunk lines (per-pane coordinates).
   if orig_cursor then
-    pcall(vim.api.nvim_win_set_cursor, orig_win, orig_cursor)
+    pcall(vim.api.nvim_win_set_cursor, orig_win, clamp_cursor(orig_win, orig_cursor))
   end
   if mod_cursor then
-    pcall(vim.api.nvim_win_set_cursor, mod_win, mod_cursor)
+    pcall(vim.api.nvim_win_set_cursor, mod_win, clamp_cursor(mod_win, mod_cursor))
   end
 
   -- Bind the two panes and align the original pane to the modified pane.

--- a/lua/codediff/ui/view/render.lua
+++ b/lua/codediff/ui/view/render.lua
@@ -5,12 +5,7 @@ local core = require("codediff.ui.core")
 local semantic = require("codediff.ui.semantic_tokens")
 local config = require("codediff.config")
 local diff_module = require("codediff.core.diff")
-
-local function clamp_cursor(win, position)
-  local bufnr = vim.api.nvim_win_get_buf(win)
-  local line_count = vim.api.nvim_buf_line_count(bufnr)
-  return { math.max(1, math.min(position[1], line_count)), position[2] or 0 }
-end
+local cursor_util = require("codediff.ui.view.cursor")
 
 --- Establish scroll synchronization between the two diff windows.
 --- Positions each pane's cursor on its own hunk line, then binds them with the
@@ -30,10 +25,10 @@ function M.establish_scrollbind(orig_win, mod_win, orig_buf, mod_buf, lines_diff
 
   -- Place cursors on their respective hunk lines (per-pane coordinates).
   if orig_cursor then
-    pcall(vim.api.nvim_win_set_cursor, orig_win, clamp_cursor(orig_win, orig_cursor))
+    pcall(vim.api.nvim_win_set_cursor, orig_win, cursor_util.clamp_cursor(orig_win, orig_cursor))
   end
   if mod_cursor then
-    pcall(vim.api.nvim_win_set_cursor, mod_win, clamp_cursor(mod_win, mod_cursor))
+    pcall(vim.api.nvim_win_set_cursor, mod_win, cursor_util.clamp_cursor(mod_win, mod_cursor))
   end
 
   -- Bind the two panes and align the original pane to the modified pane.

--- a/tests/ui/view/cycle_hunks_across_files_spec.lua
+++ b/tests/ui/view/cycle_hunks_across_files_spec.lua
@@ -44,8 +44,12 @@ describe("cycle_hunks_across_files (#161)", function()
 
   local function has_expected_hunk_count(session, expected_count)
     local changes = session and session.stored_diff_result and session.stored_diff_result.changes
-    if not changes then return false end
-    if expected_count ~= nil then return #changes == expected_count end
+    if not changes then
+      return false
+    end
+    if expected_count ~= nil then
+      return #changes == expected_count
+    end
     return #changes > 0
   end
 
@@ -90,9 +94,7 @@ describe("cycle_hunks_across_files (#161)", function()
       local s = lifecycle.get_session(tabpage)
       local e = lifecycle.get_panel_view(tabpage)
       local session_path = s and s.modified.absolute ~= "" and s.modified.absolute or s and s.original.absolute
-      return session_path and e and e.current_file_path
-        and session_path:find(e.current_file_path, 1, true) ~= nil
-        and has_expected_hunk_count(s, expected_hunk_count)
+      return session_path and e and e.current_file_path and session_path:find(e.current_file_path, 1, true) ~= nil and has_expected_hunk_count(s, expected_hunk_count)
     end, 20)
   end
 
@@ -313,5 +315,34 @@ describe("cycle_hunks_across_files (#161)", function()
 
     local cursor_after = vim.api.nvim_win_get_cursor(new_session.modified_win)[1]
     assert.equal(last_modified, cursor_after, "cursor must land on the MODIFIED-side last-hunk line (" .. last_modified .. "), not the original-side (" .. last_original .. ")")
+  end)
+
+  it("issue #479: EOF deletions use the last valid line and cross-file cycling advances", function()
+    config.options.diff.cycle_hunks_across_files = true
+
+    -- The modified side ends immediately before the deletion hunk's raw start
+    -- line. The hunk is reported as modified [4, 4), while line 3 is the last
+    -- cursor position that exists in the buffer.
+    repo.write_file("a.txt", { "a1", "a2", "a3" })
+
+    local tabpage, session, explorer = open_explorer("a.txt", 1)
+    assert.is_not_nil(session)
+    assert.is_not_nil(explorer)
+    assert.equal(3, vim.api.nvim_win_get_cursor(session.modified_win)[1], "EOF deletion should land on the last valid modified line")
+
+    local first_file = explorer.current_file_path
+    nav.next_hunk()
+    assert.is_true(wait_for_file_switch(tabpage, first_file), "next hunk should advance past the EOF deletion")
+    assert.equal("b.txt", explorer.current_file_path)
+
+    local next_session = lifecycle.get_session(tabpage)
+    local first_hunk_line = next_session.stored_diff_result.changes[1].modified.start_line
+    assert.equal(first_hunk_line, vim.api.nvim_win_get_cursor(next_session.modified_win)[1])
+
+    nav.prev_hunk()
+    assert.is_true(wait_for_file_switch(tabpage, "b.txt"), "previous hunk should return to the EOF deletion")
+    local previous_session = lifecycle.get_session(tabpage)
+    assert.equal("a.txt", explorer.current_file_path)
+    assert.equal(3, vim.api.nvim_win_get_cursor(previous_session.modified_win)[1], "backward landing should clamp the EOF deletion")
   end)
 end)


### PR DESCRIPTION
## Summary

- clamp hunk cursor targets to the last valid line in the target buffer
- allow `]c`/`[c` to cross file boundaries when a deletion ends at EOF
- clamp initial and pending cursor landings in side-by-side and inline views
- centralize cursor clamping in `lua/codediff/ui/view/cursor.lua`
- add a regression test for issue #479

## Root cause

A deletion at the end of a file is represented by a valid half-open range such as modified `[4, 4)` when the modified buffer has only three lines. Navigation treated `start_line = 4` as a cursor row. Neovim rejected that cursor position, the error was swallowed by `pcall`, and navigation returned success without advancing to the next file.

## Fix

Cursor placement now converts diff boundary coordinates to valid buffer cursor coordinates before comparing or setting the cursor. This also fixes initial and cross-file landing in both layouts.

Closes #479

## Testing

- `CODEDIFF_TEST_JOBS=2 make test-lua` — 107 spec files passed
- targeted `cycle_hunks_across_files_spec.lua` — 10 passed
- `stylua --check`
- `git diff --check`