### PR TITLE
fix(commands): allow history from active diff buffers

### DIFF
--- a/lua/codediff/commands/init.lua
+++ b/lua/codediff/commands/init.lua
@@ -300,15 +300,16 @@ function M.complete(arg_lead, cmd_line)
 end
 
 function M.vscode_diff(opts)
-  -- Toggle: close the diff view if the current tab already is one.
+  -- Toggle only when called without a subcommand. Commands such as
+  -- `:CodeDiff history` must remain dispatchable from an active diff tab.
+  local fargs, bang = opts.fargs or {}, opts.bang
   local current_tab = vim.api.nvim_get_current_tabpage()
-  if lifecycle.get_session(current_tab) then
+  if #fargs == 0 and lifecycle.get_session(current_tab) then
     lifecycle.close(current_tab)
     return
   end
 
   -- Normalize the `install!` alias into the `install` subcommand + bang.
-  local fargs, bang = opts.fargs, opts.bang
   if fargs[1] == "install!" then
     fargs = vim.list_slice(fargs, 1, #fargs)
     fargs[1] = "install"

--- a/tests/command_e2e_spec.lua
+++ b/tests/command_e2e_spec.lua
@@ -266,6 +266,43 @@ describe("Command E2E (real dispatch + render)", function()
     assert.is_true(wait_for_visible("c1"))
   end)
 
+  it("visual line history works from an active diff buffer (#463)", function()
+    vim.cmd("CodeDiff --inline file " .. repo.path("a.txt") .. " " .. repo.path("file.txt"))
+    local diff_tab = wait_for_diff_text("line 2 CHANGED")
+    assert.is_not_nil(diff_tab, "inline diff should open")
+
+    local diff_session = lifecycle.get_session(diff_tab)
+    assert.is_not_nil(diff_session)
+    vim.api.nvim_set_current_tabpage(diff_tab)
+    vim.api.nvim_set_current_win(diff_session.modified_win)
+    local modified_buf = diff_session.modified_bufnr
+    vim.api.nvim_buf_set_mark(modified_buf, "<", 1, 0, {})
+    vim.api.nvim_buf_set_mark(modified_buf, ">", 2, 0, {})
+
+    vim.cmd("'<,'>CodeDiff history")
+
+    local history_tab
+    assert.is_true(
+      vim.wait(10000, function()
+        for _, tp in ipairs(session_tabs()) do
+          local session = lifecycle.get_session(tp)
+          if session.panel and session.panel.name == "history" then
+            history_tab = tp
+            return true
+          end
+        end
+        return false
+      end, 50),
+      "visual line history should open a history session"
+    )
+
+    local history_session = lifecycle.get_session(history_tab)
+    assert.is_not_nil(history_session.panel.view)
+    assert.are.same({ 1, 2 }, history_session.panel.view.opts.line_range)
+    assert.equals("file.txt", history_session.panel.view.opts.file_path)
+    assert.is_true(wait_for_visible("c1"), "history should show commits for the selected lines")
+  end)
+
   -- ── Layout flags (on a real-file diff) ────────────────────────────────────
 
   it(":CodeDiff --inline file <a> <b> — inline layout", function()


### PR DESCRIPTION
## Summary

- keep the argument-less `:CodeDiff` command as the session close toggle
- dispatch subcommands such as `:CodeDiff history` even when the current tab already contains a diff session
- add an end-to-end regression test for `'<,'>CodeDiff history` from an inline diff buffer

## Fix

Previously, `commands.vscode_diff()` closed any active CodeDiff session before parsing the command arguments. As a result, visual line history issued from an active diff buffer never reached the history handler.

The toggle now applies only when there are no arguments. Active diff buffers can invoke history and other explicit CodeDiff subcommands normally.

Closes #463

## Testing

- `CODEDIFF_TEST_JOBS=2 make test-lua` — 106 spec files passed
- `stylua --check lua/codediff/commands/init.lua tests/command_e2e_spec.lua`
- `git diff --check`