### PR TITLE
fix(installer): update watcher and remove archive hashing

### DIFF
--- a/lua/codediff/core/installer/watcher.lua
+++ b/lua/codediff/core/installer/watcher.lua
@@ -4,16 +4,8 @@ local common = require("codediff.core.installer.common")
 local path_util = require("codediff.core.path")
 local uv = vim.uv or vim.loop
 
-local VERSION = "0.19.0"
+local VERSION = "0.23.2"
 local RELEASE_BASE = "https://github.com/esmuellert/codediff/releases/download/v" .. VERSION
-local CHECKSUMS = {
-  ["linux-arm64"] = "4ae28f18910de33ce060747ab988dced1bc3743f042083150d9b839bff27b1a2",
-  ["linux-x64"] = "ee08764bffb573f6311a6aa11a10138989ca0cbdf07f3ec0a9cafbe027a11904",
-  ["macos-arm64"] = "a6462c1f6a40066ec09e93329854df9d044a7169f6dd606af33bf6c6a0d05d7a",
-  ["macos-x64"] = "0d3a5abc189f23fa4872a791db4bf6d141517b19a6663b0799ccd7f5383f5b76",
-  ["windows-arm64"] = "7afd316746577c3ea85daf65608876e8c4bf816532cf7212cdd75b97fe85d73c",
-  ["windows-x64"] = "49a60caa8409a0f621a053fb868f2a1ceddb95eb5e33c09139ac6803013eb3fb",
-}
 local pending_callbacks = {}
 local installing = false
 
@@ -47,16 +39,6 @@ local function finish(path, err)
   for _, callback in ipairs(callbacks) do
     pcall(callback, path, err)
   end
-end
-
-local function read_file(path)
-  local file, err = io.open(path, "rb")
-  if not file then
-    return nil, err
-  end
-  local contents = file:read("*a")
-  file:close()
-  return contents
 end
 
 local function detect_platform()
@@ -120,16 +102,6 @@ local function install_watcher()
   if not downloaded then
     cleanup()
     return nil, "failed to download watcher archive: " .. download_error
-  end
-
-  local archive, archive_read_error = read_file(archive_path)
-  if not archive then
-    cleanup()
-    return nil, "failed to read watcher archive: " .. tostring(archive_read_error)
-  end
-  if vim.fn.sha256(archive) ~= CHECKSUMS[os_name .. "-" .. arch] then
-    cleanup()
-    return nil, "codediff-watcher checksum mismatch"
   end
 
   local extracted, extract_error = common.run(extract_command(archive_path, staging_dir, os_name))

--- a/tests/core/watcher_install_spec.lua
+++ b/tests/core/watcher_install_spec.lua
@@ -34,7 +34,7 @@ describe("watcher installation location", function()
   end)
 
   it("uses the versioned executable from the plugin root", function()
-    local expected = plugin_root .. "/codediff-watcher_0.19.0" .. extension
+    local expected = plugin_root .. "/codediff-watcher_0.23.2" .. extension
     vim.fn.writefile({ "stub" }, expected)
     local resolved
 
@@ -47,7 +47,7 @@ describe("watcher installation location", function()
 
   it("prefers an unversioned manual build in the plugin root", function()
     local manual = plugin_root .. "/codediff-watcher" .. extension
-    local versioned = plugin_root .. "/codediff-watcher_0.19.0" .. extension
+    local versioned = plugin_root .. "/codediff-watcher_0.23.2" .. extension
     vim.fn.writefile({ "manual" }, manual)
     vim.fn.writefile({ "downloaded" }, versioned)
     local resolved

--- a/tests/core/watcher_protocol_spec.lua
+++ b/tests/core/watcher_protocol_spec.lua
@@ -18,10 +18,10 @@ describe("watcher JSONL protocol", function()
     })
 
     decoder.feed('{"type":"rea')
-    decoder.feed('dy","protocol":1,"binary_version":"0.19.0"}\r\n{"type":"refresh","worktree":true,')
+    decoder.feed('dy","protocol":1,"binary_version":"0.23.2"}\r\n{"type":"refresh","worktree":true,')
     decoder.feed('"index":false,"head":false,"refs":false}\n')
 
-    assert.equals("0.19.0", ready.binary_version)
+    assert.equals("0.23.2", ready.binary_version)
     assert.equals(1, #refreshes)
     assert.is_true(refreshes[1].worktree)
     assert.equals(0, #errors)
@@ -50,7 +50,7 @@ describe("watcher JSONL protocol", function()
       end,
     })
 
-    decoder.feed('{"type":"ready","protocol":1,"binary_version":"0.19.0"}\n')
+    decoder.feed('{"type":"ready","protocol":1,"binary_version":"0.23.2"}\n')
     decoder.feed('{"type":"refresh","worktree":1,"index":false,"head":false,"refs":false}\n')
 
     assert.equals("watcher refresh fields must be boolean", err)


### PR DESCRIPTION
## Summary

- Remove the installer-side SHA-256 calculation for downloaded watcher archives.
- Update the bundled watcher release from `0.19.0` to `0.23.2`.
- Update watcher installation and protocol fixtures.

## Why

Neovim versions before 0.12 convert binary Lua strings containing NUL bytes to Blobs, while `vim.fn.sha256()` in those versions only accepts Strings. This caused automatic watcher installation to fail with `E976` on supported Neovim versions such as 0.11.7.

The installer continues to use the fixed GitHub Release URL and retains its existing download, extraction, cleanup, and polling fallback behavior. Release-time checksum generation remains unchanged.

Closes #553

## Testing

- `tests/core/watcher_install_spec.lua`: 2/2 on Neovim 0.13-dev.
- `tests/core/watcher_install_spec.lua`: 2/2 on Neovim 0.11.7.
- `tests/core/watcher_protocol_spec.lua`: 6/6.
- Real Neovim 0.11.7 smoke test downloaded and installed `codediff-watcher` v0.23.2 successfully.
- `stylua --check` and `git diff --check` passed.
- The full Lua suite had one unrelated local failure: `ffi_integration_spec.lua` found a locally built native library reporting version `3.1.1` while `VERSION` is `4.0.1`.